### PR TITLE
Improve Teams tab and player stats UX

### DIFF
--- a/src/components/PlayerStatsModal.tsx
+++ b/src/components/PlayerStatsModal.tsx
@@ -34,6 +34,8 @@ interface Props {
   roundFilter?: number;
   refetch?: () => void;
   isLocked?: boolean;
+  numberOfRounds?: number;
+  fantasyTeamName?: string;
 }
 
 function buildStatRows(row: PlayerHistoryRow) {
@@ -148,6 +150,8 @@ const PlayerStatsModal: React.FC<Props> = ({
   roundFilter,
   refetch,
   isLocked,
+  numberOfRounds,
+  fantasyTeamName,
 }) => {
   const { data: history, isLoading } = usePlayerHistory(playerId, seasonId);
   const [selectedRow, setSelectedRow] = useState<PlayerHistoryRow | null>(null);
@@ -174,11 +178,26 @@ const PlayerStatsModal: React.FC<Props> = ({
 
   const totalPoints = history?.reduce((sum, r) => sum + r.totalPoints, 0) ?? 0;
 
-  // What to display in the content area
-  const drillRow = roundFilter != null ? roundFilterRow : selectedRow;
+  const allRounds: (PlayerHistoryRow | null)[] = useMemo(() => {
+    if (!numberOfRounds) return history ?? [];
+    const byRound = new Map((history ?? []).map((r) => [r.roundNumber, r]));
+    return Array.from({ length: numberOfRounds }, (_, i) => byRound.get(i + 1) ?? null);
+  }, [history, numberOfRounds]);
+
+  const zeroRow: PlayerHistoryRow = useMemo(() => ({
+    roundNumber: roundFilter ?? null,
+    matchDate: null, homeTeamName: null, awayTeamName: null,
+    minutesPlayed: 0, goals: 0, assists: 0, yellowCards: 0, redCards: 0,
+    saves: 0, cleanSheet: false, goalsConceded: null, tacklesTotal: null,
+    totalPoints: 0, goalPoints: 0, assistPoints: 0, shotPoints: 0,
+    foulPoints: 0, cleanSheetPoints: 0, savePoints: 0, cardPoints: 0,
+    ownGoalPoints: 0, penaltyPoints: 0, tacklePoints: 0, goalConcededPoints: 0,
+  }), [roundFilter]);
+
+  const isMatchupMode = roundFilter != null;
+  const drillRow = isMatchupMode ? (roundFilterRow ?? zeroRow) : selectedRow;
   const showBreakdown = drillRow != null;
-  const canGoBack = showBreakdown && roundFilter == null; // back button only in history mode
-  const isMatchupMode = roundFilter != null; // opened directly from matchup
+  const canGoBack = showBreakdown && !isMatchupMode;
 
   const matchLabel = drillRow
     ? `Rodada ${drillRow.roundNumber} · ${drillRow.homeTeamName} x ${drillRow.awayTeamName}`
@@ -206,9 +225,14 @@ const PlayerStatsModal: React.FC<Props> = ({
             )}
             <Avatar src={playerPhoto} sx={{ width: 40, height: 40 }} />
             <Box>
-              <Typography fontWeight={700} variant="h6" lineHeight={1.2}>
-                {playerName ?? '—'}
-              </Typography>
+              <Box display="flex" alignItems="center" gap={1}>
+                <Typography fontWeight={700} variant="h6" lineHeight={1.2}>
+                  {playerName ?? '—'}
+                </Typography>
+                {fantasyTeamName && (
+                  <Chip label={fantasyTeamName} size="small" variant="outlined" color="primary" />
+                )}
+              </Box>
               {!showBreakdown && history && history.length > 0 && (
                 <Typography variant="caption" color="text.secondary">
                   Total: {totalPoints.toFixed(1)} pts em {history.length} jogo(s)
@@ -228,7 +252,7 @@ const PlayerStatsModal: React.FC<Props> = ({
             <Box display="flex" justifyContent="center" py={4}>
               <CircularProgress size={28} />
             </Box>
-          ) : !history || history.length === 0 ? (
+          ) : !history || (history.length === 0 && !numberOfRounds) ? (
             <Typography color="text.secondary" py={2}>
               Nenhuma estatística encontrada para esta temporada.
             </Typography>
@@ -253,7 +277,7 @@ const PlayerStatsModal: React.FC<Props> = ({
                 </TableRow>
               </TableHead>
               <TableBody>
-                {history.map((row: PlayerHistoryRow, i: number) => (
+                {allRounds.map((row, i) => row ? (
                   <TableRow
                     key={i}
                     hover
@@ -278,6 +302,21 @@ const PlayerStatsModal: React.FC<Props> = ({
                     <TableCell align="right">{row.yellowCards || '—'}</TableCell>
                     <TableCell align="right">{row.redCards || '—'}</TableCell>
                     <TableCell align="right" sx={{ color: 'text.secondary' }}>{row.minutesPlayed}</TableCell>
+                  </TableRow>
+                ) : (
+                  <TableRow key={i} sx={{ opacity: 0.45 }}>
+                    <TableCell>{i + 1}</TableCell>
+                    <TableCell>—</TableCell>
+                    <TableCell align="right" sx={{ fontWeight: 700, color: 'text.disabled' }}>0.0</TableCell>
+                    <TableCell align="right">—</TableCell>
+                    <TableCell align="right">—</TableCell>
+                    <TableCell align="right">—</TableCell>
+                    <TableCell align="center">—</TableCell>
+                    <TableCell align="right">—</TableCell>
+                    <TableCell align="right">—</TableCell>
+                    <TableCell align="right">—</TableCell>
+                    <TableCell align="right">—</TableCell>
+                    <TableCell align="right" sx={{ color: 'text.secondary' }}>—</TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/src/components/PlayersList.tsx
+++ b/src/components/PlayersList.tsx
@@ -126,7 +126,7 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
   id: number; name: string; photo: string; position: 'Defense' | 'Midfielder' | 'Attacker'; teamCode?: string;
   }>(null);
 
-  const [statsPlayer, setStatsPlayer] = useState<null | { id: number; name: string; photo: string; slotId?: number; isOwner?: boolean }>(null);
+  const [statsPlayer, setStatsPlayer] = useState<null | { id: number; name: string; photo: string; slotId?: number; isOwner?: boolean; fantasyTeamName?: string }>(null);
 
 
   const { data: slots, isLoading, refetch } = useRoster({ userTeamId, seasonYear });
@@ -305,6 +305,7 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
         <TableCell>Jogador</TableCell>
         <TableCell>Time</TableCell>
         <TableCell>Posição</TableCell>
+        <TableCell>Escalado</TableCell>
         {currentRound && <TableCell>Próx.</TableCell>}
         <TableCell align="right">
           <TableSortLabel
@@ -350,6 +351,7 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
                 photo: player.player_photo,
                 slotId,
                 isOwner: player.rostered_by_user_team_id === userTeamId,
+                fantasyTeamName: player.rostered_by_user_team_name ?? undefined,
               });
             }}
             sx={{
@@ -389,6 +391,15 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
               {POSITIONS_TRANSLATION[
                 player.player_position as keyof typeof POSITIONS_TRANSLATION
               ]}
+            </TableCell>
+            <TableCell>
+              {player.rostered_by_user_team_name ? (
+                <Typography variant="caption" color="text.secondary">
+                  {player.rostered_by_user_team_name}
+                </Typography>
+              ) : (
+                <Typography variant="caption" color="text.disabled">Livre</Typography>
+              )}
             </TableCell>
             {currentRound && (
               <TableCell>
@@ -490,7 +501,7 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
         ))
       ) : (
         <TableRow>
-          <TableCell colSpan={7}>Nenhum jogador encontrado.</TableCell>
+          <TableCell colSpan={currentRound ? 9 : 8}>Nenhum jogador encontrado.</TableCell>
         </TableRow>
       )}
     </TableBody>
@@ -502,6 +513,8 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
         playerName={statsPlayer?.name}
         playerPhoto={statsPlayer?.photo}
         seasonId={seasonId}
+        numberOfRounds={season?.numberOfRounds ?? undefined}
+        fantasyTeamName={statsPlayer?.fantasyTeamName}
         onClose={() => setStatsPlayer(null)}
         slotId={statsPlayer?.slotId}
         isOwner={statsPlayer?.isOwner}

--- a/src/components/TeamTabComponent.tsx
+++ b/src/components/TeamTabComponent.tsx
@@ -1,8 +1,6 @@
 // src/components/TeamTab.tsx
 
-import { Typography, Stack, IconButton, Paper, Alert, Chip, Box } from '@mui/material';
-import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
-import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+import { Typography, Stack, Paper, Alert, Chip, Box } from '@mui/material';
 import { useRoster } from './userTeamRosterQueries';
 import { SlotCard } from './SlotCard';
 import { useMemo, useState } from 'react';
@@ -23,15 +21,13 @@ interface Props {
     userTeam: UserTeam;
     seasonYear: number;
     seasonId?: string;
-    initialRound?: number;
     fantasyLeague: FantasyLeague;
   }
 
-  export const TeamTab: React.FC<Props> = ({ userTeam, fantasyLeague, seasonYear, seasonId, initialRound = 1 }) => {
+  export const TeamTab: React.FC<Props> = ({ userTeam, fantasyLeague, seasonYear, seasonId }) => {
     console.log('[TeamTab] seasonYear:', seasonYear);
     const [selectedSlot, setSelectedSlot] = useState<any | null>(null);
     const [isModalOpen, setIsModalOpen] = useState(false);
-    const [round, setRound] = useState(initialRound);
     const [moveOpen, setMoveOpen] = useState(false);
     const [originIndex, setOriginIndex] = useState<number | null>(null);
 
@@ -41,10 +37,10 @@ interface Props {
 
     const { data: leagueTeams } = useFantasyLeagueTeams(fantasyLeague.id);
     const { data: season } = useFantasyLeagueSeasons(fantasyLeague.id);
-    const { data: realMatches } = useRealMatchesByRound(seasonYear, round);
-    const { data: lockedTeamsData } = useLockedTeams(fantasyLeague.league.externalId, seasonYear, season?.currentRound);
+    const currentRound = season?.currentRound ?? undefined;
+    const { data: realMatches } = useRealMatchesByRound(seasonYear, currentRound);
+    const { data: lockedTeamsData } = useLockedTeams(fantasyLeague.league.externalId, seasonYear, currentRound);
     const lockedTeamIds = new Set<number>(lockedTeamsData?.lockedTeamIds ?? []);
-    const isCurrentRound = round === season?.currentRound;
     const isViewingOwnTeam = selectedTeamId === userTeam.id;
     const viewedTeam = leagueTeams?.find((t: FantasyLeagueTeamsResponse) => t.id === selectedTeamId);
 
@@ -63,9 +59,6 @@ interface Props {
     const starters = useMemo(() => slots?.filter((s: Slot) => s.slotType === 'starter') || [], [slots]);
     const bench = useMemo(() => slots?.filter((s: Slot) => s.slotType === 'bench') || [], [slots]);
   
-    const goPrev = () => setRound((r) => Math.max(1, r - 1));
-    const goNext = () => setRound((r) => r + 1);
-
     if (isLoading) return <Loading message="Carregando time..." />;
 
     if (isError) return (
@@ -99,19 +92,6 @@ interface Props {
           </Typography>
         )}
 
-        <Stack direction="row" alignItems="center" justifyContent="space-between">
-          <Typography variant="h6" fontWeight="bold">
-            Rodada {round}
-          </Typography>
-          <Stack direction="row" spacing={1}>
-            <IconButton onClick={goPrev} size="small">
-              <ArrowBackIosNewIcon fontSize="small" />
-            </IconButton>
-            <IconButton onClick={goNext} size="small">
-              <ArrowForwardIosIcon fontSize="small" />
-            </IconButton>
-          </Stack>
-        </Stack>
           <>
             <Typography variant="h6" fontWeight="bold">Titulares</Typography>
             <Stack spacing={1}>
@@ -157,11 +137,11 @@ interface Props {
         playerName={statsSlot?.player?.name}
         playerPhoto={statsSlot?.player?.photo}
         seasonId={seasonId}
+        numberOfRounds={season?.numberOfRounds ?? undefined}
         onClose={() => setStatsSlot(null)}
         slotId={isViewingOwnTeam ? statsSlot?.id : undefined}
         isOwner={isViewingOwnTeam}
         isLocked={
-          isCurrentRound &&
           statsSlot?.player?.team?.id != null &&
           lockedTeamIds.has(statsSlot.player.team.id)
         }


### PR DESCRIPTION
- Remove round navigation from Teams tab; always show current round roster
- Show all N rounds in player history modal, filling missing rounds with 0-pt placeholders
- Always show round breakdown in matchup mode, even when no stats exist
- Add fantasy team ownership column to Players tab table
- Show owning fantasy team as a chip in the player stats modal title