### PR TITLE
feat: add waiver wire UI (Mercado)

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -99,6 +99,14 @@ const endpoints = {
     playerHistory: (playerId: number, seasonId: string) => `${API_BASE_URL}/player-fantasy-points/player/${playerId}/season/${seasonId}`,
     byRound: (seasonId: string, roundNumber: number) => `${API_BASE_URL}/player-fantasy-points/season/${seasonId}/round/${roundNumber}`,
   },
+  waiver: {
+    placeClaim: `${API_BASE_URL}/waiver/claims`,
+    cancelClaim: (claimId: string) => `${API_BASE_URL}/waiver/claims/${claimId}`,
+    claimsBySeason: (seasonId: string) => `${API_BASE_URL}/waiver/claims/season/${seasonId}`,
+    historyBySeason: (seasonId: string) => `${API_BASE_URL}/waiver/claims/season/${seasonId}/history`,
+    budgetsBySeason: (seasonId: string) => `${API_BASE_URL}/waiver/budgets/season/${seasonId}`,
+    windowStatus: (leagueExternalId: number, seasonYear: number) => `${API_BASE_URL}/round-lifecycle/waiver/status/${leagueExternalId}/${seasonYear}`,
+  },
   currentSeason: `${API_BASE_URL}/current-season`,
   usersTeamsRoster: {
     addPlayer: `${API_BASE_URL}/user-team-rosters`,

--- a/src/api/useFantasyLeagueSeasons.ts
+++ b/src/api/useFantasyLeagueSeasons.ts
@@ -16,6 +16,9 @@ export interface FantasyLeagueSeason {
   status: string;
   seasonYear: number;
   currentRound: number | null;
+  waiverSystem: 'AUCTION' | 'PRIORITY';
+  initialWaiverBudget: number;
+  fantasyLeague?: { league?: { externalId?: number } };
 }
 
 export const useFantasyLeagueSeasons = (leagueId: number) => {

--- a/src/api/waiverQueries.ts
+++ b/src/api/waiverQueries.ts
@@ -1,0 +1,120 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
+import { apiConfig } from './config';
+
+const authHeader = () => ({ Authorization: `Bearer ${localStorage.getItem('token')}` });
+
+export interface WaiverClaim {
+  id: string;
+  status: 'PENDING' | 'WON' | 'LOST' | 'CANCELLED' | 'FAILED';
+  bidAmount: number;
+  resolvedAt: string | null;
+  createdAt: string;
+  userTeam: { id: number; name: string; user: { id: number; username: string } };
+  targetPlayer: { id: number; name: string; photo: string; position: string };
+  dropPlayer: { id: number; name: string } | null;
+}
+
+export interface WaiverBudget {
+  id: string;
+  remainingBudget: number;
+  userTeam: { id: number; name: string; user: { id: number; username: string } };
+}
+
+export function useWaiverClaims(seasonId: string | undefined) {
+  return useQuery<WaiverClaim[]>({
+    queryKey: ['waiverClaims', seasonId],
+    queryFn: async () => {
+      const res = await axios.get(apiConfig.endpoints.waiver.claimsBySeason(seasonId!), {
+        headers: authHeader(),
+      });
+      return res.data;
+    },
+    enabled: !!seasonId,
+    refetchInterval: 30_000,
+  });
+}
+
+export function useWaiverBudgets(seasonId: string | undefined) {
+  return useQuery<WaiverBudget[]>({
+    queryKey: ['waiverBudgets', seasonId],
+    queryFn: async () => {
+      const res = await axios.get(apiConfig.endpoints.waiver.budgetsBySeason(seasonId!), {
+        headers: authHeader(),
+      });
+      return res.data;
+    },
+    enabled: !!seasonId,
+  });
+}
+
+export interface PlaceClaimInput {
+  seasonId: string;
+  userTeamId: number;
+  targetPlayerId: number;
+  dropPlayerId?: number;
+  bidAmount: number;
+}
+
+export function usePlaceWaiverClaim() {
+  const qc = useQueryClient();
+  return useMutation<WaiverClaim, Error, PlaceClaimInput>({
+    mutationFn: async (input) => {
+      const res = await axios.post(apiConfig.endpoints.waiver.placeClaim, input, {
+        headers: authHeader(),
+      });
+      return res.data;
+    },
+    onSuccess: (_, vars) => {
+      qc.invalidateQueries({ queryKey: ['waiverClaims', vars.seasonId] });
+      qc.invalidateQueries({ queryKey: ['waiverBudgets', vars.seasonId] });
+    },
+  });
+}
+
+export interface WaiverWindowStatus {
+  window: { id: string; seasonYear: number; windowStart: string; windowEnd: string } | null;
+  isOpen: boolean;
+  pendingClaimCount: number;
+}
+
+export function useWaiverHistory(seasonId: string | undefined) {
+  return useQuery<WaiverClaim[]>({
+    queryKey: ['waiverHistory', seasonId],
+    queryFn: async () => {
+      const res = await axios.get(apiConfig.endpoints.waiver.historyBySeason(seasonId!), {
+        headers: authHeader(),
+      });
+      return res.data;
+    },
+    enabled: !!seasonId,
+  });
+}
+
+export function useWaiverWindowStatus(leagueExternalId: number | null | undefined, seasonYear: number | null | undefined) {
+  return useQuery<WaiverWindowStatus>({
+    queryKey: ['waiverWindowStatus', leagueExternalId, seasonYear],
+    queryFn: async () => {
+      const res = await axios.get(apiConfig.endpoints.waiver.windowStatus(leagueExternalId!, seasonYear!), {
+        headers: authHeader(),
+      });
+      return res.data;
+    },
+    enabled: !!leagueExternalId && !!seasonYear,
+    refetchInterval: 30_000,
+  });
+}
+
+export function useCancelWaiverClaim(seasonId: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation<void, Error, string>({
+    mutationFn: async (claimId) => {
+      await axios.delete(apiConfig.endpoints.waiver.cancelClaim(claimId), {
+        headers: authHeader(),
+      });
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['waiverClaims', seasonId] });
+    },
+  });
+}

--- a/src/components/PlayersList.tsx
+++ b/src/components/PlayersList.tsx
@@ -34,11 +34,14 @@ import {
 import ClearIcon from '@mui/icons-material/Clear';
 import LockIcon from '@mui/icons-material/Lock';
 import PersonAddAlt1Icon from '@mui/icons-material/PersonAddAlt1';
+import GavelIcon from '@mui/icons-material/Gavel';
 import { usePlayers, usePlayersFilters } from '../api/playersQueries';
 import AddPlayerModal from './AddPlayerModal';
 import PlayerStatsModal from './PlayerStatsModal';
+import WaiverClaimModal from './WaiverClaimModal';
 import { Slot, useRoster } from './userTeamRosterQueries';
 import { useRemovePlayer } from '../api/userTeamRosterMutations';
+import { useWaiverBudgets, useWaiverClaims, useWaiverWindowStatus } from '../api/waiverQueries';
 import { FantasyLeague } from '../api/fantasyLeagueQueries';
 import { useFantasyLeagueSeasons } from '../api/useFantasyLeagueSeasons';
 import { LeagueStatus } from './SeasonStatusCard';
@@ -126,6 +129,27 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
   id: number; name: string; photo: string; position: 'Defense' | 'Midfielder' | 'Attacker'; teamCode?: string;
   }>(null);
 
+  const [waiverClaimOpen, setWaiverClaimOpen] = useState(false);
+  const [waiverPlayer, setWaiverPlayer] = useState<null | { id: number; name: string; photo: string; position: string }>(null);
+
+  const leagueExternalId = season?.fantasyLeague?.league?.externalId;
+  const { data: waiverWindowStatus } = useWaiverWindowStatus(leagueExternalId, season?.seasonYear);
+  const isWaiverWindowOpen = waiverWindowStatus?.isOpen ?? false;
+
+  const { data: waiverBudgets } = useWaiverBudgets(isWaiverWindowOpen ? seasonId : undefined);
+  const { data: waiverClaims } = useWaiverClaims(isWaiverWindowOpen ? seasonId : undefined);
+
+  const myBudget = waiverBudgets?.find((b) => b.userTeam.id === userTeamId);
+  const baseBudget = myBudget ? Number(myBudget.remainingBudget) : (season?.initialWaiverBudget ?? 100);
+
+  const myClaims = waiverClaims?.filter((c) => c.userTeam.id === userTeamId) ?? [];
+  const pendingClaims = myClaims.filter((c) => c.status === 'PENDING');
+  const reservedBudget = pendingClaims.reduce((sum, c) => sum + Number(c.bidAmount), 0);
+  const remainingBudget = baseBudget - reservedBudget;
+
+  const pendingClaimedPlayerIds = new Set(pendingClaims.map((c) => c.targetPlayer.id));
+  const pendingDropPlayerIds = new Set(pendingClaims.filter((c) => c.dropPlayer).map((c) => c.dropPlayer!.id));
+
   const [statsPlayer, setStatsPlayer] = useState<null | { id: number; name: string; photo: string; slotId?: number; isOwner?: boolean; fantasyTeamName?: string }>(null);
 
 
@@ -210,9 +234,18 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
 
   return (
     <Paper variant="outlined" sx={{ p: { xs: 2, sm: 3 } }}>
-      <Typography variant="h6" gutterBottom>
-        Jogadores
-      </Typography>
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+        <Typography variant="h6">Jogadores</Typography>
+        {isWaiverWindowOpen && (
+          <Chip
+            icon={<GavelIcon />}
+            label={`Mercado aberto · R$ ${remainingBudget} disponível`}
+            color="secondary"
+            variant="outlined"
+            size="small"
+          />
+        )}
+      </Box>
 
       {!draftCompleted && (
         <Alert severity="warning" sx={{ mb: 2 }}>
@@ -436,25 +469,56 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
                   <Chip size="small" icon={<LockIcon fontSize="small" />} label="Bloqueado" color="warning" variant="outlined" />
                 </Tooltip>
               ) : !player.is_rostered ? (
-                // Free agent → Add
-                <Tooltip title="Adicionar ao elenco">
-                  <IconButton
-                    size="small"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setSelectedPlayer({
-                        id: player.player_id,
-                        name: player.player_name,
-                        photo: player.player_photo,
-                        position: player.player_position,
-                        teamCode: player.team_name,
-                      });
-                      setAddOpen(true);
-                    }}
-                  >
-                    <PersonAddAlt1Icon fontSize="small" />
-                  </IconButton>
-                </Tooltip>
+                isWaiverWindowOpen ? (
+                  pendingClaimedPlayerIds.has(player.player_id) ? (
+                    <Tooltip title="Oferta já registrada — cancele para fazer outra">
+                      <span>
+                        <IconButton size="small" disabled>
+                          <GavelIcon fontSize="small" />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                  ) : (
+                  <Tooltip title="Fazer oferta no Mercado">
+                    <IconButton
+                      size="small"
+                      color="secondary"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setWaiverPlayer({
+                          id: player.player_id,
+                          name: player.player_name,
+                          photo: player.player_photo,
+                          position: player.player_position,
+                        });
+                        setWaiverClaimOpen(true);
+                      }}
+                    >
+                      <GavelIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                  )
+                ) : (
+                  // Free agent → Add
+                  <Tooltip title="Adicionar ao elenco">
+                    <IconButton
+                      size="small"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setSelectedPlayer({
+                          id: player.player_id,
+                          name: player.player_name,
+                          photo: player.player_photo,
+                          position: player.player_position,
+                          teamCode: player.team_name,
+                        });
+                        setAddOpen(true);
+                      }}
+                    >
+                      <PersonAddAlt1Icon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                )
               ) : player.rostered_by_user_team_id === userTeamId ? (
                 // Rostered by ME → Drop
                 (() => {
@@ -533,6 +597,23 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
           userTeamId={userTeamId}
           seasonYear={seasonYear}
           refetch={() => {
+            refetchPlayers();
+            refetch();
+          }}
+        />
+      )}
+
+      {waiverClaimOpen && waiverPlayer && seasonId && (
+        <WaiverClaimModal
+          open={waiverClaimOpen}
+          onClose={() => setWaiverClaimOpen(false)}
+          seasonId={seasonId}
+          userTeamId={userTeamId}
+          remainingBudget={remainingBudget}
+          targetPlayer={waiverPlayer}
+          rosterSlots={slots ?? []}
+          pendingDropPlayerIds={pendingDropPlayerIds}
+          onSuccess={() => {
             refetchPlayers();
             refetch();
           }}

--- a/src/components/WaiverClaimModal.tsx
+++ b/src/components/WaiverClaimModal.tsx
@@ -1,0 +1,141 @@
+import React, { useState } from 'react';
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  Button, Typography, Avatar, Box, TextField, Alert,
+  FormControl, InputLabel, Select, MenuItem, Divider,
+} from '@mui/material';
+import { usePlaceWaiverClaim } from '../api/waiverQueries';
+import { Slot } from './userTeamRosterQueries';
+import { mapPositionToSlot } from '../utils/positions';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  seasonId: string;
+  userTeamId: number;
+  remainingBudget: number;
+  targetPlayer: { id: number; name: string; photo: string; position: string };
+  rosterSlots: Slot[];
+  pendingDropPlayerIds: Set<number>;
+  onSuccess: () => void;
+}
+
+export default function WaiverClaimModal({
+  open, onClose, seasonId, userTeamId, remainingBudget,
+  targetPlayer, rosterSlots, pendingDropPlayerIds, onSuccess,
+}: Props) {
+  const [bidAmount, setBidAmount] = useState<string>('');
+  const [dropPlayerId, setDropPlayerId] = useState<number | ''>('');
+  const [error, setError] = useState<string | null>(null);
+
+  const placeClaim = usePlaceWaiverClaim();
+
+  const targetSlot = mapPositionToSlot(targetPlayer.position);
+  const droppableSlots = rosterSlots.filter(
+    (s) =>
+      s.player != null &&
+      targetSlot != null &&
+      s.allowedPositions.includes(targetSlot) &&
+      !pendingDropPlayerIds.has(s.player.id),
+  );
+
+  const handleSubmit = async () => {
+    setError(null);
+    const bid = parseFloat(bidAmount);
+    if (isNaN(bid) || bid <= 0) {
+      setError('Informe um valor de lance válido maior que 0.');
+      return;
+    }
+    if (bid > remainingBudget) {
+      setError(`Oferta excede seu orçamento disponível (R$ ${remainingBudget}).`);
+      return;
+    }
+
+    try {
+      await placeClaim.mutateAsync({
+        seasonId,
+        userTeamId,
+        targetPlayerId: targetPlayer.id,
+        dropPlayerId: dropPlayerId !== '' ? dropPlayerId : undefined,
+        bidAmount: bid,
+      });
+      onSuccess();
+      handleClose();
+    } catch (err: any) {
+      setError(err?.response?.data?.message ?? 'Erro ao registrar reivindicação.');
+    }
+  };
+
+  const handleClose = () => {
+    setBidAmount('');
+    setDropPlayerId('');
+    setError(null);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Reivindicar Jogador</DialogTitle>
+      <DialogContent>
+        <Box display="flex" alignItems="center" gap={2} mb={2}>
+          <Avatar src={targetPlayer.photo} sx={{ width: 48, height: 48 }} />
+          <Box>
+            <Typography fontWeight={700}>{targetPlayer.name}</Typography>
+            <Typography variant="caption" color="text.secondary">{targetPlayer.position}</Typography>
+          </Box>
+        </Box>
+
+        <Typography variant="body2" color="text.secondary" mb={2}>
+          Orçamento disponível: <strong>R$ {remainingBudget}</strong>
+        </Typography>
+
+        <TextField
+          label="Oferta (R$)"
+          type="number"
+          value={bidAmount}
+          onChange={(e) => setBidAmount(e.target.value)}
+          inputProps={{ min: 1, max: remainingBudget, step: 1 }}
+          fullWidth
+          sx={{ mb: 2 }}
+        />
+
+        {droppableSlots.length > 0 && (
+          <>
+            <Divider sx={{ mb: 2 }} />
+            <FormControl fullWidth sx={{ mb: 1 }}>
+              <InputLabel id="drop-label">Liberar jogador (opcional)</InputLabel>
+              <Select
+                labelId="drop-label"
+                value={dropPlayerId}
+                label="Liberar jogador (opcional)"
+                onChange={(e) => setDropPlayerId(e.target.value as number | '')}
+              >
+                <MenuItem value="">Nenhum</MenuItem>
+                {droppableSlots.map((slot) => (
+                  <MenuItem key={slot.player!.id} value={slot.player!.id}>
+                    {slot.player!.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <Typography variant="caption" color="text.secondary">
+              Necessário se seu elenco estiver cheio.
+            </Typography>
+          </>
+        )}
+
+        {error && <Alert severity="error" sx={{ mt: 2 }}>{error}</Alert>}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancelar</Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={placeClaim.isPending}
+        >
+          Confirmar Oferta
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/WaiverClaimsPanel.tsx
+++ b/src/components/WaiverClaimsPanel.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import {
+  Box, Typography, Table, TableHead, TableRow, TableCell, TableBody,
+  Chip, Avatar, IconButton, Tooltip, Paper, Alert,
+} from '@mui/material';
+import CancelIcon from '@mui/icons-material/Cancel';
+import { WaiverClaim, WaiverBudget, useCancelWaiverClaim } from '../api/waiverQueries';
+
+const STATUS_LABEL: Record<string, { label: string; color: 'default' | 'success' | 'error' | 'warning' | 'info' }> = {
+  PENDING: { label: 'Pendente', color: 'info' },
+  WON: { label: 'Conquistado', color: 'success' },
+  LOST: { label: 'Perdido', color: 'default' },
+  CANCELLED: { label: 'Cancelado', color: 'warning' },
+  FAILED: { label: 'Falhou', color: 'error' },
+};
+
+interface Props {
+  seasonId: string;
+  currentUserId: number;
+  claims: WaiverClaim[];
+  budgets: WaiverBudget[];
+  isWindowOpen: boolean;
+}
+
+export default function WaiverClaimsPanel({ seasonId, currentUserId, claims, budgets, isWindowOpen }: Props) {
+  const cancelClaim = useCancelWaiverClaim(seasonId);
+
+  const myBudget = budgets.find((b) => b.userTeam.user.id === currentUserId);
+
+  const handleCancel = async (claimId: string) => {
+    try {
+      await cancelClaim.mutateAsync(claimId);
+    } catch {
+      // error handled silently; user sees claim not disappear
+    }
+  };
+
+  const myClaims = claims.filter((c) => c.userTeam.user.id === currentUserId);
+
+  if (myClaims.length === 0 && !isWindowOpen) return null;
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2 }}>
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+        <Typography variant="subtitle1" fontWeight={700}>
+          Mercado
+        </Typography>
+      </Box>
+
+      {isWindowOpen && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Mercado aberto. Use o botão "Reivindicar" na aba Jogadores para fazer uma oferta.
+        </Alert>
+      )}
+
+      {myClaims.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          Você não possui reivindicações nesta janela.
+        </Typography>
+      ) : (
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Jogador</TableCell>
+              <TableCell>Oferta</TableCell>
+              <TableCell>Liberar</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {myClaims.map((claim) => (
+              <TableRow key={claim.id}>
+                <TableCell>
+                  <Box display="flex" alignItems="center" gap={1}>
+                    <Avatar src={claim.targetPlayer.photo} sx={{ width: 24, height: 24 }} />
+                    <Typography variant="body2">{claim.targetPlayer.name}</Typography>
+                  </Box>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2">R$ {Number(claim.bidAmount).toFixed(0)}</Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2" color="text.secondary">
+                    {claim.dropPlayer?.name ?? '—'}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Chip
+                    label={STATUS_LABEL[claim.status]?.label ?? claim.status}
+                    color={STATUS_LABEL[claim.status]?.color ?? 'default'}
+                    size="small"
+                  />
+                </TableCell>
+                <TableCell align="right">
+                  {claim.status === 'PENDING' && isWindowOpen && (
+                    <Tooltip title="Cancelar reivindicação">
+                      <IconButton
+                        size="small"
+                        color="error"
+                        onClick={() => handleCancel(claim.id)}
+                        disabled={cancelClaim.isPending}
+                      >
+                        <CancelIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </Paper>
+  );
+}

--- a/src/components/WaiverHistoryModal.tsx
+++ b/src/components/WaiverHistoryModal.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import {
+  Dialog, DialogTitle, DialogContent, IconButton, Typography,
+  Box, Avatar, Chip, Divider, CircularProgress,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
+import { WaiverClaim } from '../api/waiverQueries';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  claims: WaiverClaim[];
+  isLoading: boolean;
+}
+
+interface PlayerGroup {
+  targetPlayer: WaiverClaim['targetPlayer'];
+  resolvedAt: string;
+  winner: WaiverClaim | null;
+  losers: WaiverClaim[];
+}
+
+function groupByPlayer(claims: WaiverClaim[]): PlayerGroup[] {
+  // Group by targetPlayer.id + resolvedAt date (same resolution batch)
+  const map = new Map<string, PlayerGroup>();
+
+  for (const claim of claims) {
+    const day = claim.resolvedAt ? claim.resolvedAt.substring(0, 10) : 'unknown';
+    const key = `${claim.targetPlayer.id}:${day}`;
+
+    if (!map.has(key)) {
+      map.set(key, { targetPlayer: claim.targetPlayer, resolvedAt: claim.resolvedAt ?? '', winner: null, losers: [] });
+    }
+    const group = map.get(key)!;
+    if (claim.status === 'WON') {
+      group.winner = claim;
+    } else {
+      group.losers.push(claim);
+    }
+  }
+
+  const groups = Array.from(map.values());
+
+  // Sort losers by bid desc within each group
+  groups.forEach((group) => {
+    group.losers.sort((a: WaiverClaim, b: WaiverClaim) => Number(b.bidAmount) - Number(a.bidAmount));
+  });
+
+  // Sort groups by resolvedAt desc (most recent first)
+  return groups.sort(
+    (a: PlayerGroup, b: PlayerGroup) => new Date(b.resolvedAt).getTime() - new Date(a.resolvedAt).getTime(),
+  );
+}
+
+export default function WaiverHistoryModal({ open, onClose, claims, isLoading }: Props) {
+  const groups = groupByPlayer(claims);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        <Box display="flex" justifyContent="space-between" alignItems="center">
+          Histórico do Mercado
+          <IconButton size="small" onClick={onClose}>
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        {isLoading ? (
+          <Box display="flex" justifyContent="center" py={4}>
+            <CircularProgress size={32} />
+          </Box>
+        ) : groups.length === 0 ? (
+          <Typography variant="body2" color="text.secondary" textAlign="center" py={4}>
+            Nenhuma resolução de mercado ainda.
+          </Typography>
+        ) : (
+          <Box display="flex" flexDirection="column" gap={3}>
+            {groups.map((group, i) => (
+              <Box key={i}>
+                {/* Player header */}
+                <Box display="flex" alignItems="center" gap={1.5} mb={1.5}>
+                  <Avatar src={group.targetPlayer.photo} sx={{ width: 36, height: 36 }} />
+                  <Box>
+                    <Typography fontWeight={700}>{group.targetPlayer.name}</Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {group.targetPlayer.position} ·{' '}
+                      {group.resolvedAt
+                        ? new Date(group.resolvedAt).toLocaleDateString('pt-BR', { day: '2-digit', month: 'short' })
+                        : '—'}
+                    </Typography>
+                  </Box>
+                </Box>
+
+                {/* Winner */}
+                {group.winner ? (
+                  <Box
+                    display="flex" alignItems="center" justifyContent="space-between"
+                    sx={{ bgcolor: 'success.50', border: '1px solid', borderColor: 'success.200', borderRadius: 1, px: 1.5, py: 1, mb: 1 }}
+                  >
+                    <Box display="flex" alignItems="center" gap={1}>
+                      <EmojiEventsIcon fontSize="small" color="success" />
+                      <Typography variant="body2" fontWeight={700}>{group.winner.userTeam.name}</Typography>
+                      {group.winner.dropPlayer && (
+                        <Typography variant="caption" color="text.secondary">
+                          · liberou {group.winner.dropPlayer.name}
+                        </Typography>
+                      )}
+                    </Box>
+                    <Chip label={`R$ ${Number(group.winner.bidAmount).toFixed(0)}`} color="success" size="small" />
+                  </Box>
+                ) : (
+                  <Typography variant="caption" color="error">Nenhum vencedor (falha na execução)</Typography>
+                )}
+
+                {/* Losers */}
+                {group.losers.map((loser) => (
+                  <Box
+                    key={loser.id}
+                    display="flex" alignItems="center" justifyContent="space-between"
+                    sx={{ px: 1.5, py: 0.75 }}
+                  >
+                    <Typography variant="body2" color="text.secondary">{loser.userTeam.name}</Typography>
+                    <Chip label={`R$ ${Number(loser.bidAmount).toFixed(0)}`} size="small" variant="outlined" />
+                  </Box>
+                ))}
+
+                {i < groups.length - 1 && <Divider sx={{ mt: 2 }} />}
+              </Box>
+            ))}
+          </Box>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/pages/FantasyLeague.tsx
+++ b/src/pages/FantasyLeague.tsx
@@ -4,11 +4,13 @@ import { useGetFantasyLeague } from '../api/fantasyLeagueQueries';
 import LeagueSidebar from '../components/FantasyLeaguesSidebar';
 import InviteToLeagueModal from '../components/InviteToFantasyLeagueModal';
 import { useInviteUserToFantasyLeague } from '../api/fantasyLeagueQueries';
-import { Snackbar, Alert, Box, useMediaQuery, useTheme } from '@mui/material';
+import { Snackbar, Alert, Box, Button, useMediaQuery, useTheme } from '@mui/material';
 import LeagueTabs from '../components/FantasyLeagueTabs';
 import ViewInvitesModal from '../components/ViewInvitesModal';
 import FantasyLeagueInfo from '../components/FantasyLeagueInfo';
 import PlayersList from '../components/PlayersList';
+import WaiverClaimsPanel from '../components/WaiverClaimsPanel';
+import WaiverHistoryModal from '../components/WaiverHistoryModal';
 import { TeamTab } from '../components/TeamTabComponent';
 import { useFindUserFantasyLeagueTeam } from '../api/userTeamsQueries';
 import Loading from '../components/Loading';
@@ -16,6 +18,7 @@ import DraftTab from '../components/DraftTab';
 import ScheduleTab from '../components/ScheduleTab';
 import { useFantasyLeagueSeasons } from '../api/useFantasyLeagueSeasons';
 import { useCurrentSeason } from '../api/currentSeasonQueries';
+import { useWaiverClaims, useWaiverBudgets, useWaiverWindowStatus, useWaiverHistory } from '../api/waiverQueries';
 
 const FantasyLeaguePage = ({ currentUserId }: { currentUserId: number }) => {
   const { fantasyLeagueId } = useParams<{ fantasyLeagueId: string }>();
@@ -28,6 +31,7 @@ const FantasyLeaguePage = ({ currentUserId }: { currentUserId: number }) => {
   });
   const [selectedTab, setSelectedTab] = useState('draft');
   const [viewInvitesModalOpen, setViewInvitesModalOpen] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -36,6 +40,23 @@ const FantasyLeaguePage = ({ currentUserId }: { currentUserId: number }) => {
   const { data: fantasyLeagueSeason } = useFantasyLeagueSeasons(Number(fantasyLeagueId));
   const { data: currentSeasonData } = useCurrentSeason();
   const seasonYear = fantasyLeagueSeason?.seasonYear ?? currentSeasonData?.year ?? new Date().getFullYear();
+
+  const leagueExternalId = fantasyLeagueSeason?.fantasyLeague?.league?.externalId;
+  const { data: waiverWindowStatus } = useWaiverWindowStatus(
+    selectedTab === 'players' ? leagueExternalId : null,
+    selectedTab === 'players' ? fantasyLeagueSeason?.seasonYear : null,
+  );
+  const isWaiverWindowOpen = waiverWindowStatus?.isOpen ?? false;
+
+  const { data: waiverClaims } = useWaiverClaims(
+    selectedTab === 'players' && fantasyLeagueSeason?.id ? fantasyLeagueSeason.id : undefined,
+  );
+  const { data: waiverBudgets } = useWaiverBudgets(
+    selectedTab === 'players' && fantasyLeagueSeason?.id ? fantasyLeagueSeason.id : undefined,
+  );
+  const { data: waiverHistory = [], isLoading: isHistoryLoading } = useWaiverHistory(
+    selectedTab === 'players' ? fantasyLeagueSeason?.id : undefined,
+  );
 
 
   const handleInvite = (email: string) => {
@@ -96,11 +117,38 @@ const FantasyLeaguePage = ({ currentUserId }: { currentUserId: number }) => {
           {selectedTab === 'team' && <TeamTab seasonYear={seasonYear} seasonId={fantasyLeagueSeason?.id} userTeam={userTeam} fantasyLeague={fantasyLeague} />}
           {selectedTab === 'schedule' && <ScheduleTab seasonId={fantasyLeagueSeason?.id} userTeamId={userTeam?.id} seasonYear={seasonYear} currentRound={fantasyLeagueSeason?.currentRound ?? null} />}
           {selectedTab === 'league' && <FantasyLeagueInfo currentUserId={currentUserId} fantasyLeague={fantasyLeague} />}
-          {selectedTab === 'players' && <PlayersList fantasyLeague={fantasyLeague} seasonYear={seasonYear} userTeamId={userTeam.id} seasonId={fantasyLeagueSeason?.id} />}
+          {selectedTab === 'players' && (
+            <Box display="flex" flexDirection="column" gap={2}>
+              {fantasyLeagueSeason?.id && (
+                <Box display="flex" justifyContent="flex-end">
+                  <Button variant="outlined" size="small" onClick={() => setHistoryOpen(true)}>
+                    Histórico do Mercado
+                  </Button>
+                </Box>
+              )}
+              {isWaiverWindowOpen && fantasyLeagueSeason?.id && (
+                <WaiverClaimsPanel
+                  seasonId={fantasyLeagueSeason.id}
+                  currentUserId={currentUserId}
+                  claims={waiverClaims ?? []}
+                  budgets={waiverBudgets ?? []}
+                  isWindowOpen={isWaiverWindowOpen}
+                />
+              )}
+              <PlayersList fantasyLeague={fantasyLeague} seasonYear={seasonYear} userTeamId={userTeam.id} seasonId={fantasyLeagueSeason?.id} />
+            </Box>
+          )}
           {selectedTab === 'trades' && <div>Trades UI</div>}
           {selectedTab === 'scores' && <div>Scores table</div>}
         </Box>
       </Box>
+
+      <WaiverHistoryModal
+        open={historyOpen}
+        onClose={() => setHistoryOpen(false)}
+        claims={waiverHistory}
+        isLoading={isHistoryLoading}
+      />
 
       <InviteToLeagueModal
         open={inviteModalOpen}


### PR DESCRIPTION
## Summary

- Players tab switches to claim mode when the waiver window is open: "Adicionar" becomes "Reivindicar" (gavel icon), direct adds are blocked
- Budget chip shows effective remaining budget (DB remaining minus pending-bid reserves)
- `WaiverClaimModal`: bid amount input + position-compatible drop-player selector (excludes already-pending drop targets)
- `WaiverClaimsPanel`: user's own pending claims with cancel button; only visible when window is open
- `WaiverHistoryModal` ("Histórico do Mercado"): resolved claims grouped by player and date, always accessible

## Why

The backend waiver wire (added in `fantasy-football-api` PR #39) needs a corresponding UI. The design goal is zero confusion about which mode the player tab is in: the budget chip and button label change unambiguously when the window opens. Users can see only their own pending claims to avoid revealing bid amounts to opponents. The history modal provides transparency after resolution. See `work/2026-05-waiver-wire/design.md` in `fantasy-docs`.

## In scope

- `src/api/config.ts` — waiver endpoint URLs
- `src/api/waiverQueries.ts` — React Query hooks for window status, claims, budgets, history
- `src/components/PlayersList.tsx` — window-aware UI: claim button, budget chip, pending state
- `src/components/WaiverClaimModal.tsx` — bid input + filtered drop selector
- `src/components/WaiverClaimsPanel.tsx` — own pending claims + cancel
- `src/components/WaiverHistoryModal.tsx` — resolved claim history
- `src/pages/FantasyLeague.tsx` — history button, modal state wiring
- `src/api/useFantasyLeagueSeasons.ts` — added `fantasyLeague.league.externalId` to season type

## Out of scope

- Trade UI (Trocas)
- Admin window management UI (handled via curl/admin API)
- Mobile-specific layout

## Verification

- [x] Window closed: "Adicionar" shown, clicking adds player directly
- [x] Window open: budget chip visible, "Reivindicar" shown, placing a claim reserves budget in UI immediately
- [x] Already-claimed player: gavel button disabled with tooltip
- [x] Drop selector: only shows position-compatible slots; excludes players already pending drop in another claim
- [x] Cancel claim: claim removed from panel, budget freed
- [x] After window closes: claims panel hidden, history modal shows resolved results

## Follow-ups

- Trade system UI (Trocas)
- Budget carry-over display if multi-season budget resets are added