### PR TITLE
feat(admin): round games CRUD tab + full Portuguese translation of ad…

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -77,12 +77,18 @@ const endpoints = {
   fantasyRoundGames: {
     lockedTeams: (leagueExternalId: number, seasonYear: number, roundNumber: number) =>
       `${API_BASE_URL}/fantasy-round-games/league/${leagueExternalId}/season/${seasonYear}/round/${roundNumber}/locked-teams`,
+    syncAll: (leagueExternalId: number, seasonYear: number) =>
+      `${API_BASE_URL}/fantasy-round-games/league/${leagueExternalId}/season/${seasonYear}/sync-all`,
     syncFromRealRound: (leagueExternalId: number, seasonYear: number, roundNumber: number) =>
       `${API_BASE_URL}/fantasy-round-games/league/${leagueExternalId}/season/${seasonYear}/round/${roundNumber}/sync`,
     listMatches: (leagueExternalId: number, seasonYear: number, roundNumber: number) =>
       `${API_BASE_URL}/fantasy-round-games/league/${leagueExternalId}/season/${seasonYear}/round/${roundNumber}/matches`,
+    addMatch: (leagueExternalId: number, seasonYear: number, roundNumber: number, matchId: number) =>
+      `${API_BASE_URL}/fantasy-round-games/league/${leagueExternalId}/season/${seasonYear}/round/${roundNumber}/matches/${matchId}`,
     removeMatch: (leagueExternalId: number, seasonYear: number, roundNumber: number, matchId: number) =>
       `${API_BASE_URL}/fantasy-round-games/league/${leagueExternalId}/season/${seasonYear}/round/${roundNumber}/matches/${matchId}`,
+    orphaned: (leagueExternalId: number, seasonYear: number) =>
+      `${API_BASE_URL}/fantasy-round-games/league/${leagueExternalId}/season/${seasonYear}/orphaned`,
   },
   matches: {
     byRound: (seasonYear: number, roundNumber: number) =>

--- a/src/api/fantasyRoundGameQueries.ts
+++ b/src/api/fantasyRoundGameQueries.ts
@@ -1,8 +1,26 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import { apiConfig } from './config';
 
 const authHeader = () => ({ Authorization: `Bearer ${localStorage.getItem('token')}` });
+
+export interface RoundGameMatch {
+  matchId: number;
+  externalId: number | null;
+  homeTeam: { id: number; name: string } | null;
+  awayTeam: { id: number; name: string } | null;
+  date: string | null;
+  status: string;
+  statusLong: string | null;
+  homeGoals: number | null;
+  awayGoals: number | null;
+}
+
+export interface OrphanedMatch extends RoundGameMatch {
+  roundNumber: number | null;
+}
+
+// ─── Queries ────────────────────────────────────────────────────────────────
 
 export const useLockedTeams = (
   leagueExternalId: number | undefined,
@@ -22,3 +40,127 @@ export const useLockedTeams = (
     refetchInterval: 2 * 60 * 1000,
     staleTime: 0,
   });
+
+export const useListRoundMatches = (
+  leagueExternalId: number | undefined,
+  seasonYear: number | undefined,
+  roundNumber: number | undefined,
+) =>
+  useQuery<RoundGameMatch[]>({
+    queryKey: ['roundGameMatches', leagueExternalId, seasonYear, roundNumber],
+    queryFn: async () => {
+      const res = await axios.get(
+        apiConfig.endpoints.fantasyRoundGames.listMatches(leagueExternalId!, seasonYear!, roundNumber!),
+        { headers: authHeader() },
+      );
+      return res.data;
+    },
+    enabled: !!leagueExternalId && !!seasonYear && roundNumber != null,
+    staleTime: 0,
+  });
+
+export const useOrphanedMatches = (
+  leagueExternalId: number | undefined,
+  seasonYear: number | undefined,
+) =>
+  useQuery<OrphanedMatch[]>({
+    queryKey: ['orphanedMatches', leagueExternalId, seasonYear],
+    queryFn: async () => {
+      const res = await axios.get(
+        apiConfig.endpoints.fantasyRoundGames.orphaned(leagueExternalId!, seasonYear!),
+        { headers: authHeader() },
+      );
+      return res.data;
+    },
+    enabled: !!leagueExternalId && !!seasonYear,
+    staleTime: 0,
+  });
+
+// ─── Mutations ───────────────────────────────────────────────────────────────
+
+function invalidateRoundGames(
+  qc: ReturnType<typeof useQueryClient>,
+  leagueExternalId: number,
+  seasonYear: number,
+) {
+  qc.invalidateQueries({ queryKey: ['roundGameMatches', leagueExternalId, seasonYear] });
+  qc.invalidateQueries({ queryKey: ['orphanedMatches', leagueExternalId, seasonYear] });
+}
+
+export const useSyncAllRounds = () => {
+  const qc = useQueryClient();
+  return useMutation<
+    { rounds: number; totalAdded: number },
+    Error,
+    { leagueExternalId: number; seasonYear: number }
+  >({
+    mutationFn: async ({ leagueExternalId, seasonYear }) => {
+      const res = await axios.post(
+        apiConfig.endpoints.fantasyRoundGames.syncAll(leagueExternalId, seasonYear),
+        {},
+        { headers: authHeader() },
+      );
+      return res.data;
+    },
+    onSuccess: (_data, { leagueExternalId, seasonYear }) =>
+      invalidateRoundGames(qc, leagueExternalId, seasonYear),
+  });
+};
+
+export const useSyncRound = () => {
+  const qc = useQueryClient();
+  return useMutation<
+    { added: number },
+    Error,
+    { leagueExternalId: number; seasonYear: number; roundNumber: number }
+  >({
+    mutationFn: async ({ leagueExternalId, seasonYear, roundNumber }) => {
+      const res = await axios.post(
+        apiConfig.endpoints.fantasyRoundGames.syncFromRealRound(leagueExternalId, seasonYear, roundNumber),
+        {},
+        { headers: authHeader() },
+      );
+      return res.data;
+    },
+    onSuccess: (_data, { leagueExternalId, seasonYear }) =>
+      invalidateRoundGames(qc, leagueExternalId, seasonYear),
+  });
+};
+
+export const useAddMatch = () => {
+  const qc = useQueryClient();
+  return useMutation<
+    { added: boolean },
+    Error,
+    { leagueExternalId: number; seasonYear: number; roundNumber: number; matchId: number }
+  >({
+    mutationFn: async ({ leagueExternalId, seasonYear, roundNumber, matchId }) => {
+      const res = await axios.post(
+        apiConfig.endpoints.fantasyRoundGames.addMatch(leagueExternalId, seasonYear, roundNumber, matchId),
+        {},
+        { headers: authHeader() },
+      );
+      return res.data;
+    },
+    onSuccess: (_data, { leagueExternalId, seasonYear }) =>
+      invalidateRoundGames(qc, leagueExternalId, seasonYear),
+  });
+};
+
+export const useRemoveMatch = () => {
+  const qc = useQueryClient();
+  return useMutation<
+    void,
+    Error,
+    { leagueExternalId: number; seasonYear: number; roundNumber: number; matchId: number }
+  >({
+    mutationFn: async ({ leagueExternalId, seasonYear, roundNumber, matchId }) => {
+      await axios.delete(
+        apiConfig.endpoints.fantasyRoundGames.removeMatch(leagueExternalId, seasonYear, roundNumber, matchId),
+        { headers: authHeader() },
+      );
+    },
+    onSuccess: (_data, { leagueExternalId, seasonYear }) =>
+      invalidateRoundGames(qc, leagueExternalId, seasonYear),
+  });
+};

--- a/src/pages/admin/AdminRoundFlowPage.tsx
+++ b/src/pages/admin/AdminRoundFlowPage.tsx
@@ -12,12 +12,14 @@ import {
   MenuItem,
   Paper,
   Stack,
+  Tab,
   Table,
   TableBody,
   TableCell,
   TableContainer,
   TableHead,
   TableRow,
+  Tabs,
   TextField,
   Tooltip,
   Typography,
@@ -36,6 +38,7 @@ import {
   useTriggerRoundFlowEvent,
   useUpdateRoundFlow,
 } from '../../api/roundFlowQueries';
+import RoundGamesTab from './RoundGamesTab';
 
 const STATUS_COLORS: Record<RoundFlowStatus, 'default' | 'success' | 'info' | 'warning' | 'secondary' | 'error'> = {
   PENDING: 'default',
@@ -60,6 +63,24 @@ function toLocalInput(iso: string): string {
 }
 
 const AdminRoundFlowPage: React.FC = () => {
+  const [tab, setTab] = useState(0);
+
+  return (
+    <Box sx={{ p: 3, maxWidth: 1400, mx: 'auto' }}>
+      <Typography variant="h4" fontWeight="bold" sx={{ mb: 2 }}>
+        Painel Admin
+      </Typography>
+      <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 3, borderBottom: 1, borderColor: 'divider' }}>
+        <Tab label="Fluxo de Rodada" />
+        <Tab label="Jogos da Rodada" />
+      </Tabs>
+      {tab === 0 && <RoundFlowTab />}
+      {tab === 1 && <RoundGamesTab />}
+    </Box>
+  );
+};
+
+const RoundFlowTab: React.FC = () => {
   const { data: roundFlows = [], isLoading } = useRoundFlows();
   const activate = useActivateRoundFlow();
   const update = useUpdateRoundFlow();
@@ -71,17 +92,17 @@ const AdminRoundFlowPage: React.FC = () => {
   const [triggerMenu, setTriggerMenu] = useState<{ rf: RoundFlow; anchor: HTMLElement } | null>(null);
 
   return (
-    <Box sx={{ p: 3, maxWidth: 1400, mx: 'auto' }}>
+    <Box>
       <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 3 }}>
-        <Typography variant="h4" fontWeight="bold">
-          Round Flow
+        <Typography variant="h5" fontWeight="bold">
+          Fluxo de Rodada
         </Typography>
         <Button
           variant="contained"
           startIcon={<AddIcon />}
           onClick={() => setActivateOpen(true)}
         >
-          Activate Round
+          Ativar Rodada
         </Button>
       </Stack>
 
@@ -90,26 +111,26 @@ const AdminRoundFlowPage: React.FC = () => {
           <Table size="small">
             <TableHead>
               <TableRow>
-                <TableCell>League</TableCell>
-                <TableCell>Season</TableCell>
-                <TableCell>Round</TableCell>
+                <TableCell>Liga</TableCell>
+                <TableCell>Temporada</TableCell>
+                <TableCell>Rodada</TableCell>
                 <TableCell>Status</TableCell>
-                <TableCell>Live Start</TableCell>
-                <TableCell>Round End</TableCell>
-                <TableCell>Waiver Open</TableCell>
-                <TableCell>Waiver Resolve</TableCell>
-                <TableCell align="right">Actions</TableCell>
+                <TableCell>Início Ao Vivo</TableCell>
+                <TableCell>Fim da Rodada</TableCell>
+                <TableCell>Abertura do Mercado</TableCell>
+                <TableCell>Fechamento do Mercado</TableCell>
+                <TableCell align="right">Ações</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
               {isLoading && (
                 <TableRow>
-                  <TableCell colSpan={9} align="center">Loading...</TableCell>
+                  <TableCell colSpan={9} align="center">Carregando...</TableCell>
                 </TableRow>
               )}
               {!isLoading && roundFlows.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={9} align="center">No round flows yet — activate one to start.</TableCell>
+                  <TableCell colSpan={9} align="center">Nenhum fluxo de rodada ainda — ative um para começar.</TableCell>
                 </TableRow>
               )}
               {roundFlows.map((rf) => (
@@ -126,35 +147,35 @@ const AdminRoundFlowPage: React.FC = () => {
                     />
                   </TableCell>
                   <TableCell>
-                    <Tooltip title={rf.liveScoringStartedAt ? `Fired: ${formatDt(rf.liveScoringStartedAt)}` : ''}>
+                    <Tooltip title={rf.liveScoringStartedAt ? `Disparado: ${formatDt(rf.liveScoringStartedAt)}` : ''}>
                       <span style={{ textDecoration: rf.liveScoringStartedAt ? 'line-through' : 'none' }}>
                         {formatDt(rf.liveScoringStartAt)}
                       </span>
                     </Tooltip>
                   </TableCell>
                   <TableCell>
-                    <Tooltip title={rf.scoredAt ? `Fired: ${formatDt(rf.scoredAt)}` : ''}>
+                    <Tooltip title={rf.scoredAt ? `Disparado: ${formatDt(rf.scoredAt)}` : ''}>
                       <span style={{ textDecoration: rf.scoredAt ? 'line-through' : 'none' }}>
                         {formatDt(rf.roundEndAt)}
                       </span>
                     </Tooltip>
                   </TableCell>
                   <TableCell>
-                    <Tooltip title={rf.waiverWindowOpenedAt ? `Fired: ${formatDt(rf.waiverWindowOpenedAt)}` : ''}>
+                    <Tooltip title={rf.waiverWindowOpenedAt ? `Disparado: ${formatDt(rf.waiverWindowOpenedAt)}` : ''}>
                       <span style={{ textDecoration: rf.waiverWindowOpenedAt ? 'line-through' : 'none' }}>
                         {formatDt(rf.waiverWindowStartAt)}
                       </span>
                     </Tooltip>
                   </TableCell>
                   <TableCell>
-                    <Tooltip title={rf.waiverResolvedAt ? `Fired: ${formatDt(rf.waiverResolvedAt)}` : ''}>
+                    <Tooltip title={rf.waiverResolvedAt ? `Disparado: ${formatDt(rf.waiverResolvedAt)}` : ''}>
                       <span style={{ textDecoration: rf.waiverResolvedAt ? 'line-through' : 'none' }}>
                         {formatDt(rf.waiverResolveAt)}
                       </span>
                     </Tooltip>
                   </TableCell>
                   <TableCell align="right">
-                    <Tooltip title="Edit deadlines">
+                    <Tooltip title="Editar prazos">
                       <span>
                         <IconButton
                           size="small"
@@ -165,7 +186,7 @@ const AdminRoundFlowPage: React.FC = () => {
                         </IconButton>
                       </span>
                     </Tooltip>
-                    <Tooltip title="Trigger event now">
+                    <Tooltip title="Disparar evento agora">
                       <span>
                         <IconButton
                           size="small"
@@ -176,7 +197,7 @@ const AdminRoundFlowPage: React.FC = () => {
                         </IconButton>
                       </span>
                     </Tooltip>
-                    <Tooltip title="Cancel">
+                    <Tooltip title="Cancelar">
                       <span>
                         <IconButton
                           size="small"
@@ -188,7 +209,7 @@ const AdminRoundFlowPage: React.FC = () => {
                             rf.status === 'CANCELED'
                           }
                           onClick={() => {
-                            if (window.confirm(`Cancel round flow #${rf.id}?`)) cancel.mutate(rf.id);
+                            if (window.confirm(`Cancelar o fluxo de rodada #${rf.id}?`)) cancel.mutate(rf.id);
                           }}
                         >
                           <CancelIcon fontSize="small" />
@@ -239,7 +260,7 @@ const AdminRoundFlowPage: React.FC = () => {
             onClick={() => {
               const rf = triggerMenu!.rf;
               setTriggerMenu(null);
-              if (window.confirm(`Trigger '${event}' for round flow #${rf.id} now?`)) {
+              if (window.confirm(`Disparar '${event}' para o fluxo de rodada #${rf.id} agora?`)) {
                 trigger.mutate({ id: rf.id, event });
               }
             }}
@@ -274,26 +295,26 @@ const ActivateRoundDialog: React.FC<{
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
-      <DialogTitle>Activate Round Flow</DialogTitle>
+      <DialogTitle>Ativar Fluxo de Rodada</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
           <TextField
-            label="League External ID"
+            label="ID Externo da Liga"
             type="number"
             value={leagueExternalId}
             onChange={(e) => setLeagueExternalId(e.target.value)}
-            helperText="71 = Brasileirão Serie A"
+            helperText="71 = Brasileirão Série A"
             fullWidth
           />
           <TextField
-            label="Season Year"
+            label="Ano da Temporada"
             type="number"
             value={seasonYear}
             onChange={(e) => setSeasonYear(e.target.value)}
             fullWidth
           />
           <TextField
-            label="Round Number"
+            label="Número da Rodada"
             type="number"
             value={roundNumber}
             onChange={(e) => setRoundNumber(e.target.value)}
@@ -306,9 +327,9 @@ const ActivateRoundDialog: React.FC<{
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={onClose}>Cancelar</Button>
         <Button variant="contained" onClick={submit} disabled={isPending}>
-          {isPending ? 'Activating...' : 'Activate'}
+          {isPending ? 'Ativando...' : 'Ativar'}
         </Button>
       </DialogActions>
     </Dialog>
@@ -361,43 +382,43 @@ const EditDeadlinesDialog: React.FC<{
 
   return (
     <Dialog open onClose={onClose} fullWidth maxWidth="xs">
-      <DialogTitle>Edit Deadlines — Round {roundFlow.roundNumber}</DialogTitle>
+      <DialogTitle>Editar Prazos — Rodada {roundFlow.roundNumber}</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
           <TextField
-            label="Live Scoring Start"
+            label="Início da Pontuação Ao Vivo"
             type="datetime-local"
             value={liveStart}
             onChange={(e) => setLiveStart(e.target.value)}
             disabled={!!roundFlow.liveScoringStartedAt}
-            InputLabelProps={{ shrink: true }}
+            slotProps={{ inputLabel: { shrink: true } }}
             fullWidth
           />
           <TextField
-            label="Round End (scoring)"
+            label="Fim da Rodada (pontuação)"
             type="datetime-local"
             value={roundEnd}
             onChange={(e) => setRoundEnd(e.target.value)}
             disabled={!!roundFlow.scoredAt}
-            InputLabelProps={{ shrink: true }}
+            slotProps={{ inputLabel: { shrink: true } }}
             fullWidth
           />
           <TextField
-            label="Waiver Window Open"
+            label="Abertura do Mercado"
             type="datetime-local"
             value={waiverOpen}
             onChange={(e) => setWaiverOpen(e.target.value)}
             disabled={!!roundFlow.waiverWindowOpenedAt}
-            InputLabelProps={{ shrink: true }}
+            slotProps={{ inputLabel: { shrink: true } }}
             fullWidth
           />
           <TextField
-            label="Waiver Resolve"
+            label="Fechamento do Mercado"
             type="datetime-local"
             value={waiverResolve}
             onChange={(e) => setWaiverResolve(e.target.value)}
             disabled={!!roundFlow.waiverResolvedAt}
-            InputLabelProps={{ shrink: true }}
+            slotProps={{ inputLabel: { shrink: true } }}
             fullWidth
           />
           {errorMessage && (
@@ -406,9 +427,9 @@ const EditDeadlinesDialog: React.FC<{
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={onClose}>Cancelar</Button>
         <Button variant="contained" onClick={submit} disabled={isPending}>
-          {isPending ? 'Saving...' : 'Save'}
+          {isPending ? 'Salvando...' : 'Salvar'}
         </Button>
       </DialogActions>
     </Dialog>

--- a/src/pages/admin/RoundGamesTab.tsx
+++ b/src/pages/admin/RoundGamesTab.tsx
@@ -1,0 +1,357 @@
+import React, { useState } from 'react';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  IconButton,
+  Snackbar,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AddIcon from '@mui/icons-material/Add';
+import SyncIcon from '@mui/icons-material/Sync';
+import {
+  OrphanedMatch,
+  useAddMatch,
+  useListRoundMatches,
+  useOrphanedMatches,
+  useRemoveMatch,
+  useSyncAllRounds,
+  useSyncRound,
+} from '../../api/fantasyRoundGameQueries';
+
+// ─── Round row (one accordion item) ─────────────────────────────────────────
+
+const RoundRow: React.FC<{
+  leagueExternalId: number;
+  seasonYear: number;
+  roundNumber: number;
+  onMessage: (msg: string) => void;
+}> = ({ leagueExternalId, seasonYear, roundNumber, onMessage }) => {
+  const [expanded, setExpanded] = useState(false);
+  const { data: matches = [], isLoading } = useListRoundMatches(
+    expanded ? leagueExternalId : undefined,
+    expanded ? seasonYear : undefined,
+    expanded ? roundNumber : undefined,
+  );
+  const syncRound = useSyncRound();
+  const removeMatch = useRemoveMatch();
+
+  const handleSync = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    syncRound.mutate(
+      { leagueExternalId, seasonYear, roundNumber },
+      { onSuccess: (d) => onMessage(`Rodada ${roundNumber}: ${d.added} jogo(s) adicionado(s)`) },
+    );
+  };
+
+  const handleRemove = (matchId: number) => {
+    if (!window.confirm(`Remover o jogo ${matchId} da rodada ${roundNumber}?`)) return;
+    removeMatch.mutate(
+      { leagueExternalId, seasonYear, roundNumber, matchId },
+      { onSuccess: () => onMessage(`Jogo removido da rodada ${roundNumber}`) },
+    );
+  };
+
+  return (
+    <Accordion expanded={expanded} onChange={(_, v) => setExpanded(v)}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Stack direction="row" alignItems="center" spacing={2} sx={{ width: '100%', pr: 1 }}>
+          <Typography fontWeight="bold" sx={{ minWidth: 80 }}>
+            Rodada {roundNumber}
+          </Typography>
+          {expanded && !isLoading && (
+            <Chip size="small" label={`${matches.length} jogo(s)`} />
+          )}
+          <Box sx={{ flexGrow: 1 }} />
+          <Tooltip title="Sincronizar esta rodada">
+            <span>
+              <IconButton
+                size="small"
+                disabled={syncRound.isPending}
+                onClick={handleSync}
+              >
+                <SyncIcon fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
+        </Stack>
+      </AccordionSummary>
+      <AccordionDetails sx={{ p: 0 }}>
+        {isLoading ? (
+          <Box sx={{ p: 2, display: 'flex', justifyContent: 'center' }}>
+            <CircularProgress size={20} />
+          </Box>
+        ) : matches.length === 0 ? (
+          <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
+            Nenhum jogo atribuído — use Sincronizar ou adicione da lista de órfãos abaixo.
+          </Typography>
+        ) : (
+          <TableContainer>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Casa</TableCell>
+                  <TableCell>Fora</TableCell>
+                  <TableCell>Data</TableCell>
+                  <TableCell>Status</TableCell>
+                  <TableCell align="right" />
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {matches.map((m) => (
+                  <TableRow key={m.matchId} hover>
+                    <TableCell>{m.homeTeam?.name ?? '—'}</TableCell>
+                    <TableCell>{m.awayTeam?.name ?? '—'}</TableCell>
+                    <TableCell>
+                      {m.date
+                        ? new Date(m.date).toLocaleString('pt-BR', { timeZone: 'America/Sao_Paulo' })
+                        : '—'}
+                    </TableCell>
+                    <TableCell>
+                      <Chip size="small" label={m.status} variant="outlined" />
+                    </TableCell>
+                    <TableCell align="right">
+                      <Tooltip title="Remover da rodada">
+                        <IconButton
+                          size="small"
+                          color="error"
+                          disabled={removeMatch.isPending}
+                          onClick={() => handleRemove(m.matchId)}
+                        >
+                          <DeleteIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </AccordionDetails>
+    </Accordion>
+  );
+};
+
+// ─── Orphaned match row ──────────────────────────────────────────────────────
+
+const OrphanedRow: React.FC<{
+  match: OrphanedMatch;
+  leagueExternalId: number;
+  seasonYear: number;
+  onMessage: (msg: string) => void;
+}> = ({ match, leagueExternalId, seasonYear, onMessage }) => {
+  const [targetRound, setTargetRound] = useState(String(match.roundNumber ?? ''));
+  const addMatch = useAddMatch();
+
+  const handleAdd = () => {
+    const roundNumber = Number(targetRound);
+    if (!roundNumber) return;
+    addMatch.mutate(
+      { leagueExternalId, seasonYear, roundNumber, matchId: match.matchId },
+      {
+        onSuccess: (d) =>
+          onMessage(
+            d.added
+              ? `Jogo adicionado à rodada ${roundNumber}`
+              : `Jogo já está na rodada ${roundNumber}`,
+          ),
+        onError: (err) => onMessage(`Erro: ${err.message}`),
+      },
+    );
+  };
+
+  return (
+    <TableRow hover>
+      <TableCell>{match.homeTeam?.name ?? '—'}</TableCell>
+      <TableCell>{match.awayTeam?.name ?? '—'}</TableCell>
+      <TableCell>
+        {match.date
+          ? new Date(match.date).toLocaleString('pt-BR', { timeZone: 'America/Sao_Paulo' })
+          : '—'}
+      </TableCell>
+      <TableCell>
+        <Chip size="small" label={match.status} variant="outlined" />
+      </TableCell>
+      <TableCell>{match.roundNumber ?? '—'}</TableCell>
+      <TableCell align="right">
+        <Stack direction="row" spacing={1} alignItems="center" justifyContent="flex-end">
+          <TextField
+            size="small"
+            type="number"
+            label="Rodada"
+            value={targetRound}
+            onChange={(e) => setTargetRound(e.target.value)}
+            sx={{ width: 80 }}
+            inputProps={{ min: 1, max: 38 }}
+          />
+          <Tooltip title="Adicionar à rodada">
+            <span>
+              <IconButton
+                size="small"
+                color="primary"
+                disabled={!targetRound || addMatch.isPending}
+                onClick={handleAdd}
+              >
+                <AddIcon fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
+        </Stack>
+      </TableCell>
+    </TableRow>
+  );
+};
+
+// ─── Main tab ────────────────────────────────────────────────────────────────
+
+const TOTAL_ROUNDS = 38;
+
+const RoundGamesTab: React.FC = () => {
+  const [leagueId, setLeagueId] = useState('71');
+  const [seasonYear, setSeasonYear] = useState(String(new Date().getFullYear()));
+  const [snack, setSnack] = useState<string | null>(null);
+
+  const leagueExternalId = Number(leagueId) || undefined;
+  const year = Number(seasonYear) || undefined;
+
+  const { data: orphaned = [], isLoading: orphanedLoading } = useOrphanedMatches(
+    leagueExternalId,
+    year,
+  );
+  const syncAll = useSyncAllRounds();
+
+  const handleSyncAll = () => {
+    if (!leagueExternalId || !year) return;
+    syncAll.mutate(
+      { leagueExternalId, seasonYear: year },
+      {
+        onSuccess: (d) =>
+          setSnack(`${d.rounds} rodada(s) sincronizada(s) — ${d.totalAdded} jogo(s) adicionado(s)`),
+        onError: (err) => setSnack(`Erro: ${err.message}`),
+      },
+    );
+  };
+
+  return (
+    <Box>
+      {/* Controls */}
+      <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 3 }}>
+        <TextField
+          label="ID Externo da Liga"
+          type="number"
+          value={leagueId}
+          onChange={(e) => setLeagueId(e.target.value)}
+          size="small"
+          sx={{ width: 160 }}
+          helperText="71 = Brasileirão"
+        />
+        <TextField
+          label="Ano da Temporada"
+          type="number"
+          value={seasonYear}
+          onChange={(e) => setSeasonYear(e.target.value)}
+          size="small"
+          sx={{ width: 120 }}
+        />
+        <Button
+          variant="contained"
+          startIcon={syncAll.isPending ? <CircularProgress size={16} color="inherit" /> : <SyncIcon />}
+          disabled={!leagueExternalId || !year || syncAll.isPending}
+          onClick={handleSyncAll}
+        >
+          Sincronizar Todas as Rodadas
+        </Button>
+      </Stack>
+
+      {/* Rounds accordion */}
+      <Typography variant="h6" fontWeight="bold" sx={{ mb: 1 }}>
+        Rodadas
+      </Typography>
+      <Box sx={{ mb: 4 }}>
+        {Array.from({ length: TOTAL_ROUNDS }, (_, i) => i + 1).map((n) => (
+          <RoundRow
+            key={n}
+            leagueExternalId={leagueExternalId ?? 0}
+            seasonYear={year ?? 0}
+            roundNumber={n}
+            onMessage={setSnack}
+          />
+        ))}
+      </Box>
+
+      {/* Orphaned matches */}
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+        <Typography variant="h6" fontWeight="bold">
+          Jogos Órfãos
+        </Typography>
+        {!orphanedLoading && (
+          <Chip size="small" label={orphaned.length} color={orphaned.length > 0 ? 'warning' : 'default'} />
+        )}
+      </Stack>
+
+      {orphanedLoading ? (
+        <CircularProgress size={24} />
+      ) : orphaned.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          Nenhum jogo órfão — todos os jogos estão atribuídos a uma rodada.
+        </Typography>
+      ) : (
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Casa</TableCell>
+                <TableCell>Fora</TableCell>
+                <TableCell>Data</TableCell>
+                <TableCell>Status</TableCell>
+                <TableCell>Rodada Real</TableCell>
+                <TableCell align="right">Adicionar à Rodada</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {orphaned.map((m) => (
+                <OrphanedRow
+                  key={m.matchId}
+                  match={m}
+                  leagueExternalId={leagueExternalId ?? 0}
+                  seasonYear={year ?? 0}
+                  onMessage={setSnack}
+                />
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      <Snackbar
+        open={snack != null}
+        autoHideDuration={4000}
+        onClose={() => setSnack(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity="info" onClose={() => setSnack(null)} sx={{ width: '100%' }}>
+          {snack}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+};
+
+export default RoundGamesTab;


### PR DESCRIPTION
…min panel

- Add RoundGamesTab: league/season selector, 38-round accordion (lazy per-round loading), per-round sync + remove, orphaned matches table with inline add-to-round control
- Wrap AdminRoundFlowPage in MUI Tabs: "Fluxo de Rodada" | "Jogos da Rodada"
- Expand fantasyRoundGameQueries: useListRoundMatches, useOrphanedMatches, useSyncAllRounds, useSyncRound, useAddMatch, useRemoveMatch
- Add syncAll, addMatch, orphaned endpoints to config.ts
- Translate entire admin panel to Portuguese (Painel Admin, Fluxo de Rodada, Abertura do Mercado, Fechamento do Mercado, etc.)
- Replace deprecated InputLabelProps with slotProps.inputLabel