### PR TITLE
Add project-context section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,21 @@
+## Project context
+
+This repo is part of the **caneta-fantasy** fantasy soccer platform. The cross-cutting project documentation lives in the sibling repo `fantasy-docs` at `~/repositories/fantasy/fantasy-docs/`:
+
+- Conventions (commits, branching, PRs apply to this repo too): `../fantasy-docs/CONVENTIONS.md`
+- Glossary (PT ↔ EN domain terms): `../fantasy-docs/GLOSSARY.md`
+- Architecture decisions (ADRs): `../fantasy-docs/decisions/`
+- Work items in progress (design + plan): `../fantasy-docs/work/`
+- Onboarding for new contributors: `../fantasy-docs/ONBOARDING.md`
+
+### Install the project skill
+
+For full project context across all caneta-fantasy repos, install the `caneta-fantasy-workflow` skill: symlink `../fantasy-docs/skills/caneta-fantasy-workflow.md` to `~/.claude/skills/caneta-fantasy-workflow.md`. With the skill installed, Claude has direct pointers to the project's flow (brainstorm → spec → plan → implement), conventions, and topology — for every session in any of the three repos.
+
+If you're new to the project, start with `../fantasy-docs/ONBOARDING.md`.
+
+---
+
 # Fantasy Football Frontend
 
 React 19 application for the fantasy football platform.


### PR DESCRIPTION
## Summary

- Prepends a "Project context" section to \`CLAUDE.md\` so Claude sessions in this repo know about the cross-cutting \`fantasy-docs\` repo and the \`caneta-fantasy-workflow\` skill.
- Keeps all existing FE tech/pattern content unchanged.

## Why

\`fantasy-docs\` (at \`caneta-fantasy/fantasy-docs\`) holds the project's vision, conventions, glossary, ADRs, and per-work-item design+plan pairs. Without a pointer from this repo's \`CLAUDE.md\`, Claude sessions here have no idea those resources exist. The new section gives Claude (and human readers) direct paths to the cross-cutting docs and the project skill.

Design + plan: [\`caneta-fantasy/fantasy-docs/work/2026-05-peer-onboarding/\`](https://github.com/caneta-fantasy/fantasy-docs/tree/main/work/2026-05-peer-onboarding).

## In scope

- One section prepended to \`CLAUDE.md\` (about 20 lines).

## Out of scope

- Any other change to \`CLAUDE.md\`.
- Code changes.

## Verification

- [x] \`head -3 CLAUDE.md\` shows the new section title.
- [x] The original top-level heading still appears below the new section.
- [x] No other files modified.

## Follow-ups

- Same change lands in \`fantasy-football-api/CLAUDE.md\` in parallel (separate PR).