### PR TITLE
feat: playoffs UI — visual bracket, round selector with mata-mata chi…

### DIFF
--- a/src/api/fantasyMatchupQueries.ts
+++ b/src/api/fantasyMatchupQueries.ts
@@ -11,9 +11,13 @@ export interface FantasyMatchupDto {
   awayTeamName: string | null;
   homeScore: number | null;
   awayScore: number | null;
+  winnerId: number | null;
   status: string;
   matchupType: string;
   isGhost: boolean;
+  playoffStage: number | null;
+  twoLegPairId: string | null;
+  playoffSeed: { homeSeed: number; awaySeed: number } | null;
 }
 
 export interface ScheduleByRoundDto {

--- a/src/api/useFantasyLeagueSeasons.ts
+++ b/src/api/useFantasyLeagueSeasons.ts
@@ -19,6 +19,7 @@ export interface FantasyLeagueSeason {
   waiverSystem: 'AUCTION' | 'PRIORITY';
   initialWaiverBudget: number;
   fantasyLeague?: { league?: { externalId?: number } };
+  championTeamId: number | null;
 }
 
 export const useFantasyLeagueSeasons = (leagueId: number) => {

--- a/src/components/PlayersList.tsx
+++ b/src/components/PlayersList.tsx
@@ -156,7 +156,6 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
 
 
   const { data: slots, isLoading, refetch } = useRoster({ userTeamId, seasonYear });
-  console.log(slots);
 
   const playerIdToSlotId = React.useMemo(() => {
     const m = new Map<number, number>();

--- a/src/components/PlayoffBracket.tsx
+++ b/src/components/PlayoffBracket.tsx
@@ -1,20 +1,460 @@
-import React from 'react';
-import { Box, CircularProgress, Divider, Stack, Typography } from '@mui/material';
+import React, { useMemo } from 'react';
+import { Box, CircularProgress, Paper, Typography } from '@mui/material';
 import { usePlayoffMatchups, FantasyMatchupDto } from '../api/fantasyMatchupQueries';
-import MatchupCard from './MatchupCard';
 
-const STAGE_NAMES: Record<number, string> = {
-  3: 'Quartas de Final',
+interface Props {
+  seasonId: string | undefined;
+  seasonYear?: number;
+}
+
+interface BracketSlot {
+  position: number; // better seed of the pair (1 = best)
+  stage: number;
+  legs: FantasyMatchupDto[]; // 1 or 2 legs
+}
+
+interface TieResult {
+  homeTotal: number | null;
+  awayTotal: number | null;
+  winnerId: number | null;
+}
+
+function computeTieResult(legs: FantasyMatchupDto[]): TieResult {
+  if (legs.length === 0) return { homeTotal: null, awayTotal: null, winnerId: null };
+
+  if (legs.length === 1) {
+    const leg = legs[0];
+    return { homeTotal: leg.homeScore, awayTotal: leg.awayScore, winnerId: leg.winnerId };
+  }
+
+  const sorted = [...legs].sort((a, b) => a.roundNumber - b.roundNumber);
+  const leg1 = sorted[0];
+  const leg2 = sorted[1];
+
+  if (leg1.homeScore == null || leg1.awayScore == null || leg2.homeScore == null || leg2.awayScore == null) {
+    return { homeTotal: leg1.homeScore, awayTotal: leg1.awayScore, winnerId: null };
+  }
+
+  // Leg 1: home = original home. Leg 2: home = original away (reversed).
+  // original home aggregate = leg1.home + leg2.away
+  const homeAggregate = Number(leg1.homeScore) + Number(leg2.awayScore);
+  const awayAggregate = Number(leg1.awayScore) + Number(leg2.homeScore);
+  const winnerId = homeAggregate >= awayAggregate ? leg1.homeTeamId : leg1.awayTeamId;
+
+  return { homeTotal: homeAggregate, awayTotal: awayAggregate, winnerId };
+}
+
+// Standard bracket seed order top-to-bottom for a column of N slots.
+// This follows the classic 1v(n), 2v(n-1), ... seeding where 1 is top.
+// We store per-slot the "position" = min(homeSeed, awaySeed).
+// Quarter positions for 4 slots: [1, 4, 2, 3] → 1v4 on top, 2v3 on bottom (standard bracket)
+// Semi positions for 2 slots: [1, 2]
+// Final positions for 1 slot: [1]
+function getVisualSlotOrder(stage: number): number[] {
+  switch (stage) {
+    case 3: return [1, 4, 2, 3]; // 8-team quarters: 1v8 top, 4v5 second, 2v7 third, 3v6 bottom
+    case 2: return [1, 2];
+    case 1: return [1];
+    default: return Array.from({ length: Math.pow(2, stage - 1) }, (_, i) => i + 1);
+  }
+}
+
+// Build a Map<stage, Map<position, BracketSlot>> from flat matchup list
+function buildSlots(matchups: FantasyMatchupDto[]): Map<number, Map<number, BracketSlot>> {
+  // Group by stage
+  const byStage = new Map<number, FantasyMatchupDto[]>();
+  for (const matchup of matchups) {
+    if (matchup.playoffStage == null) continue;
+    const group = byStage.get(matchup.playoffStage) ?? [];
+    group.push(matchup);
+    byStage.set(matchup.playoffStage, group);
+  }
+
+  const result = new Map<number, Map<number, BracketSlot>>();
+
+  byStage.forEach((stageMatchups, stage) => {
+    const slotMap = new Map<number, BracketSlot>();
+
+    // Group two-leg pairs together, keep singles separate
+    const byPair = new Map<string, FantasyMatchupDto[]>();
+    const singles: FantasyMatchupDto[] = [];
+
+    for (const matchup of stageMatchups) {
+      if (matchup.twoLegPairId) {
+        const group = byPair.get(matchup.twoLegPairId) ?? [];
+        group.push(matchup);
+        byPair.set(matchup.twoLegPairId, group);
+      } else {
+        singles.push(matchup);
+      }
+    }
+
+    for (const matchup of singles) {
+      if (matchup.isGhost) continue;
+      const seed = matchup.playoffSeed;
+      const position = seed ? Math.min(seed.homeSeed, seed.awaySeed) : 0;
+      slotMap.set(position, { position, stage, legs: [matchup] });
+    }
+
+    byPair.forEach((legs) => {
+      if (legs[0].isGhost) return;
+      const seed = legs[0].playoffSeed;
+      const position = seed ? Math.min(seed.homeSeed, seed.awaySeed) : 0;
+      const sorted = [...legs].sort((a, b) => a.roundNumber - b.roundNumber);
+      slotMap.set(position, { position, stage, legs: sorted });
+    });
+
+    result.set(stage, slotMap);
+  });
+
+  return result;
+}
+
+// Detect bye teams by finding seeds that appear in a later-stage (semi) matchup
+// but have no corresponding quarter matchup
+function detectByeTeams(
+  topStage: number,
+  slotsByStage: Map<number, Map<number, BracketSlot>>,
+): Map<number, string> {
+  const byeMap = new Map<number, string>();
+  if (topStage < 3) return byeMap; // no quarters stage = no byes
+
+  const quarterSlots = slotsByStage.get(topStage);
+  const semiSlots = slotsByStage.get(topStage - 1);
+  if (!quarterSlots || !semiSlots) return byeMap;
+
+  const visualOrder = getVisualSlotOrder(topStage);
+
+  visualOrder.forEach((position) => {
+    if (quarterSlots.has(position)) return; // real matchup exists, no bye
+
+    // Position has no quarter matchup — find which team has this seed by looking at semis
+    semiSlots.forEach((semiSlot) => {
+      const seed = semiSlot.legs[0].playoffSeed;
+      if (!seed) return;
+      const rep = semiSlot.legs[0];
+      if (seed.homeSeed === position && rep.homeTeamName) {
+        byeMap.set(position, rep.homeTeamName);
+      } else if (seed.awaySeed === position && rep.awayTeamName) {
+        byeMap.set(position, rep.awayTeamName);
+      }
+    });
+  });
+
+  return byeMap;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Components
+// ──────────────────────────────────────────────────────────────────────────────
+
+const SLOT_HEIGHT = 84;
+const SLOT_WIDTH = 210;
+const CONNECTOR_W = 28;
+
+const scoreStr = (score: number | null) =>
+  score == null ? '-' : Number(score).toFixed(2).replace('.', ',');
+
+interface TeamRowProps {
+  name: string | null;
+  score: number | null;
+  leg1Score?: number | null;
+  leg2Score?: number | null;
+  isTwoLeg: boolean;
+  isWinner: boolean;
+  hasBorder: boolean;
+}
+
+const TeamRow: React.FC<TeamRowProps> = ({ name, score, leg1Score, leg2Score, isTwoLeg, isWinner, hasBorder }) => (
+  <Box
+    sx={{
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      px: 1,
+      py: 0.65,
+      bgcolor: isWinner ? 'action.selected' : 'transparent',
+      borderBottom: hasBorder ? '1px solid' : 'none',
+      borderColor: 'divider',
+      minWidth: 0,
+    }}
+  >
+    <Typography
+      variant="caption"
+      fontWeight={isWinner ? 800 : 400}
+      noWrap
+      sx={{ flex: 1, mr: 0.75, fontSize: 11, lineHeight: 1.3 }}
+    >
+      {name ?? '?'}
+    </Typography>
+    {isTwoLeg ? (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.4, flexShrink: 0 }}>
+        <Typography variant="caption" sx={{ fontSize: 10, color: 'text.disabled' }}>
+          {scoreStr(leg1Score ?? null)}
+        </Typography>
+        <Typography variant="caption" sx={{ fontSize: 9, color: 'text.disabled' }}>/</Typography>
+        <Typography variant="caption" sx={{ fontSize: 10, color: 'text.disabled' }}>
+          {scoreStr(leg2Score ?? null)}
+        </Typography>
+        <Typography
+          variant="caption"
+          fontWeight={isWinner ? 800 : 600}
+          sx={{ fontSize: 11, minWidth: 34, textAlign: 'right' }}
+        >
+          {scoreStr(score)}
+        </Typography>
+      </Box>
+    ) : (
+      <Typography variant="caption" fontWeight={isWinner ? 800 : 600} sx={{ fontSize: 11, flexShrink: 0 }}>
+        {scoreStr(score)}
+      </Typography>
+    )}
+  </Box>
+);
+
+const MatchupBox: React.FC<{ slot: BracketSlot }> = ({ slot }) => {
+  const { legs } = slot;
+  const rep = legs[0];
+  const isTwoLeg = legs.length === 2;
+  const sorted = isTwoLeg ? [...legs].sort((a, b) => a.roundNumber - b.roundNumber) : legs;
+  const leg1 = sorted[0];
+  const leg2 = isTwoLeg ? sorted[1] : null;
+  const tieResult = computeTieResult(legs);
+  const homeWon = tieResult.winnerId != null && tieResult.winnerId === rep.homeTeamId;
+  const awayWon = tieResult.winnerId != null && tieResult.winnerId === rep.awayTeamId;
+
+  // For two-leg: leg1 home row = leg1.home + leg2.away; leg1 away row = leg1.away + leg2.home
+  const homeLeg1 = isTwoLeg ? leg1.homeScore : null;
+  const homeLeg2 = isTwoLeg && leg2 ? leg2.awayScore : null;
+  const awayLeg1 = isTwoLeg ? leg1.awayScore : null;
+  const awayLeg2 = isTwoLeg && leg2 ? leg2.homeScore : null;
+
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        width: SLOT_WIDTH,
+        borderRadius: 1.5,
+        overflow: 'hidden',
+        borderColor: 'divider',
+      }}
+    >
+      <TeamRow
+        name={rep.homeTeamName}
+        score={tieResult.homeTotal}
+        leg1Score={homeLeg1}
+        leg2Score={homeLeg2}
+        isTwoLeg={isTwoLeg}
+        isWinner={homeWon}
+        hasBorder
+      />
+      <TeamRow
+        name={rep.awayTeamName}
+        score={tieResult.awayTotal}
+        leg1Score={awayLeg1}
+        leg2Score={awayLeg2}
+        isTwoLeg={isTwoLeg}
+        isWinner={awayWon}
+        hasBorder={false}
+      />
+    </Paper>
+  );
+};
+
+const ByeBox: React.FC<{ teamName: string }> = ({ teamName }) => (
+  <Paper
+    variant="outlined"
+    sx={{ width: SLOT_WIDTH, borderRadius: 1.5, overflow: 'hidden', borderColor: 'divider', bgcolor: 'action.hover' }}
+  >
+    <Box sx={{ px: 1, py: 0.65, borderBottom: '1px solid', borderColor: 'divider' }}>
+      <Typography variant="caption" fontWeight={700} noWrap sx={{ fontSize: 11 }}>
+        {teamName}
+      </Typography>
+    </Box>
+    <Box sx={{ px: 1, py: 0.65 }}>
+      <Typography variant="caption" color="text.disabled" sx={{ fontSize: 10 }}>Bye</Typography>
+    </Box>
+  </Paper>
+);
+
+const TbdBox: React.FC = () => (
+  <Paper
+    variant="outlined"
+    sx={{ width: SLOT_WIDTH, borderRadius: 1.5, overflow: 'hidden', borderColor: 'divider', opacity: 0.4 }}
+  >
+    <Box sx={{ px: 1, py: 0.65, borderBottom: '1px solid', borderColor: 'divider' }}>
+      <Typography variant="caption" color="text.secondary" sx={{ fontSize: 11 }}>A definir</Typography>
+    </Box>
+    <Box sx={{ px: 1, py: 0.65 }}>
+      <Typography variant="caption" color="text.secondary" sx={{ fontSize: 11 }}>A definir</Typography>
+    </Box>
+  </Paper>
+);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Bracket geometry helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+function totalRows(maxStage: number): number {
+  return Math.pow(2, maxStage - 1); // e.g. stage 3 → 4 rows, stage 2 → 2 rows
+}
+
+// Vertical center of slot at index `slotIndex` in a column with `slotCount` slots,
+// given total canvas height = totalRows(maxStage) * SLOT_HEIGHT
+function slotCenterY(slotIndex: number, slotCount: number, maxStage: number): number {
+  const canvasH = totalRows(maxStage) * SLOT_HEIGHT;
+  const cellH = canvasH / slotCount;
+  return slotIndex * cellH + cellH / 2;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Column + connector
+// ──────────────────────────────────────────────────────────────────────────────
+
+interface ColumnProps {
+  stage: number;
+  maxStage: number;
+  slotMap: Map<number, BracketSlot>;
+  visualOrder: number[];
+  byeTeams: Map<number, string>;
+}
+
+const BracketColumn: React.FC<ColumnProps> = ({ maxStage, slotMap, visualOrder, byeTeams }) => {
+  const canvasH = totalRows(maxStage) * SLOT_HEIGHT;
+  const slotCount = visualOrder.length;
+
+  return (
+    <Box sx={{ position: 'relative', width: SLOT_WIDTH, height: canvasH, flexShrink: 0 }}>
+      {visualOrder.map((position, slotIndex) => {
+        const centerY = slotCenterY(slotIndex, slotCount, maxStage);
+        const topY = centerY - SLOT_HEIGHT / 2;
+        const slot = slotMap.get(position);
+        const byeName = byeTeams.get(position);
+
+        return (
+          <Box
+            key={position}
+            sx={{
+              position: 'absolute',
+              top: topY,
+              left: 0,
+              width: SLOT_WIDTH,
+              height: SLOT_HEIGHT,
+              display: 'flex',
+              alignItems: 'center',
+            }}
+          >
+            {byeName ? <ByeBox teamName={byeName} /> : slot ? <MatchupBox slot={slot} /> : <TbdBox />}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+};
+
+interface ConnectorProps {
+  leftStage: number;
+  maxStage: number;
+  leftOrder: number[];
+  rightOrder: number[];
+}
+
+const ConnectorSvg: React.FC<ConnectorProps> = ({ maxStage, leftOrder, rightOrder }) => {
+  const canvasH = totalRows(maxStage) * SLOT_HEIGHT;
+  const leftCount = leftOrder.length;
+  const rightCount = rightOrder.length;
+  const w = CONNECTOR_W + 8;
+
+  const lines: React.ReactNode[] = [];
+
+  // Each right slot gets 2 left slots feeding into it
+  rightOrder.forEach((_, rightIndex) => {
+    const leftA = leftOrder[rightIndex * 2];
+    const leftB = leftOrder[rightIndex * 2 + 1];
+    if (leftA === undefined || leftB === undefined) return;
+
+    const idxA = leftOrder.indexOf(leftA);
+    const idxB = leftOrder.indexOf(leftB);
+    const yA = slotCenterY(idxA, leftCount, maxStage);
+    const yB = slotCenterY(idxB, leftCount, maxStage);
+    const yRight = slotCenterY(rightIndex, rightCount, maxStage);
+    const midX = w / 2;
+
+    lines.push(
+      <g key={`${leftA}-${leftB}`}>
+        <line x1={0} y1={yA} x2={midX} y2={yA} stroke="currentColor" strokeWidth={1.5} />
+        <line x1={0} y1={yB} x2={midX} y2={yB} stroke="currentColor" strokeWidth={1.5} />
+        <line x1={midX} y1={yA} x2={midX} y2={yB} stroke="currentColor" strokeWidth={1.5} />
+        <line x1={midX} y1={yRight} x2={w} y2={yRight} stroke="currentColor" strokeWidth={1.5} />
+      </g>,
+    );
+  });
+
+  return (
+    <Box
+      component="svg"
+      sx={{ width: w, height: canvasH, flexShrink: 0, color: 'divider', overflow: 'visible' }}
+      viewBox={`0 0 ${w} ${canvasH}`}
+    >
+      {lines}
+    </Box>
+  );
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PlayoffBracket
+// ──────────────────────────────────────────────────────────────────────────────
+
+const STAGE_LABELS: Record<number, string> = {
+  3: 'Quartas',
   2: 'Semifinal',
   1: 'Final',
 };
 
-interface Props {
-  seasonId: string | undefined;
-}
-
-const PlayoffBracket: React.FC<Props> = ({ seasonId }) => {
+const PlayoffBracket: React.FC<Props> = ({ seasonId, seasonYear }) => {
   const { data: matchups, isLoading } = usePlayoffMatchups(seasonId);
+
+  const slotsByStage = useMemo(() => {
+    if (!matchups) return new Map<number, Map<number, BracketSlot>>();
+    return buildSlots(matchups);
+  }, [matchups]);
+
+  const stages = useMemo(() => {
+    if (!matchups || matchups.length === 0) return [];
+    const stageSet = new Set<number>();
+    matchups.forEach((matchup) => {
+      if (matchup.playoffStage != null) stageSet.add(matchup.playoffStage);
+    });
+    return Array.from(stageSet).sort((a, b) => b - a); // descending: quarters → semi → final
+  }, [matchups]);
+
+  const maxStage = useMemo(() => (stages.length > 0 ? stages[0] : 1), [stages]);
+
+  const visualOrderByStage = useMemo(() => {
+    const map = new Map<number, number[]>();
+    stages.forEach((stage) => map.set(stage, getVisualSlotOrder(stage)));
+    return map;
+  }, [stages]);
+
+  const byeTeams = useMemo(() => {
+    if (stages.length === 0) return new Map<number, string>();
+    return detectByeTeams(maxStage, slotsByStage);
+  }, [maxStage, stages, slotsByStage]);
+
+  const championName = useMemo(() => {
+    const finalSlots = slotsByStage.get(1);
+    if (!finalSlots || finalSlots.size === 0) return null;
+    const finalSlot = Array.from(finalSlots.values())[0];
+    const tieResult = computeTieResult(finalSlot.legs);
+    if (tieResult.winnerId == null) return null;
+    const rep = finalSlot.legs[0];
+    return tieResult.winnerId === rep.homeTeamId ? rep.homeTeamName : rep.awayTeamName;
+  }, [slotsByStage]);
+
+  const hasTwoLeg = useMemo(
+    () => !!matchups && matchups.some((matchup) => matchup.twoLegPairId != null),
+    [matchups],
+  );
 
   if (!seasonId) return null;
 
@@ -29,38 +469,91 @@ const PlayoffBracket: React.FC<Props> = ({ seasonId }) => {
   if (!matchups || matchups.length === 0) {
     return (
       <Typography color="text.secondary" textAlign="center" py={4}>
-        Os playoffs ainda não foram gerados.
+        O mata-mata ainda não foi gerado.
       </Typography>
     );
   }
 
-  // Group by stage (highest stage = earliest round, displayed first)
-  const byStage = new Map<number, FantasyMatchupDto[]>();
-  for (const m of matchups) {
-    const stage = (m as any).playoffStage ?? 0;
-    const group = byStage.get(stage) ?? [];
-    group.push(m);
-    byStage.set(stage, group);
-  }
-
-  const stages = Array.from(byStage.keys()).sort((a, b) => b - a);
-
   return (
-    <Stack spacing={4}>
-      {stages.map((stage) => (
-        <Box key={stage}>
-          <Typography variant="h6" fontWeight={700} mb={2}>
-            {STAGE_NAMES[stage] ?? `Estágio ${stage}`}
+    <Box>
+      {championName && (
+        <Paper
+          elevation={0}
+          sx={{
+            p: 2.5,
+            mb: 3,
+            borderRadius: 3,
+            textAlign: 'center',
+            background: 'linear-gradient(135deg, #f59e0b22 0%, #f59e0b11 100%)',
+            border: '1.5px solid',
+            borderColor: 'warning.main',
+          }}
+        >
+          <Typography variant="h5" fontWeight={800} color="warning.main">
+            🏆 {championName}
           </Typography>
-          <Stack spacing={1.5}>
-            {byStage.get(stage)!.map((m) => (
-              <MatchupCard key={m.id} matchup={m} />
-            ))}
-          </Stack>
-          <Divider sx={{ mt: 3 }} />
-        </Box>
-      ))}
-    </Stack>
+          <Typography variant="body2" color="text.secondary" mt={0.5}>
+            Campeão{seasonYear ? ` da temporada ${seasonYear}` : ''}
+          </Typography>
+        </Paper>
+      )}
+
+      {/* Column headers */}
+      <Box sx={{ display: 'flex', mb: 1 }}>
+        {stages.map((stage, stageIndex) => (
+          <React.Fragment key={stage}>
+            <Box sx={{ width: SLOT_WIDTH, flexShrink: 0, textAlign: 'left' }}>
+              <Typography
+                variant="caption"
+                fontWeight={700}
+                color="text.secondary"
+                sx={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.5 }}
+              >
+                {STAGE_LABELS[stage] ?? `Estágio ${stage}`}
+              </Typography>
+            </Box>
+            {stageIndex < stages.length - 1 && (
+              <Box sx={{ width: CONNECTOR_W + 8, flexShrink: 0 }} />
+            )}
+          </React.Fragment>
+        ))}
+      </Box>
+
+      {/* Bracket */}
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', overflowX: 'auto', pb: 2 }}>
+        {stages.map((stage, stageIndex) => {
+          const slotMap = slotsByStage.get(stage) ?? new Map<number, BracketSlot>();
+          const visualOrder = visualOrderByStage.get(stage) ?? [];
+          const nextStage = stages[stageIndex + 1];
+
+          return (
+            <React.Fragment key={stage}>
+              <BracketColumn
+                stage={stage}
+                maxStage={maxStage}
+                slotMap={slotMap}
+                visualOrder={visualOrder}
+                byeTeams={stageIndex === 0 ? byeTeams : new Map()}
+              />
+              {nextStage !== undefined && (
+                <ConnectorSvg
+                  leftStage={stage}
+                  maxStage={maxStage}
+                  leftOrder={visualOrder}
+                  rightOrder={visualOrderByStage.get(nextStage) ?? []}
+                />
+              )}
+            </React.Fragment>
+          );
+        })}
+      </Box>
+
+      {hasTwoLeg && (
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+          Placar: J1 / J2 — Agregado
+        </Typography>
+      )}
+    </Box>
   );
 };
 

--- a/src/components/ScheduleTab.tsx
+++ b/src/components/ScheduleTab.tsx
@@ -12,7 +12,7 @@ import {
 } from '@mui/material';
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
-import { useScheduleBySeason, ScheduleByRoundDto, FantasyMatchupDto } from '../api/fantasyMatchupQueries';
+import { useScheduleBySeason, usePlayoffMatchups, FantasyMatchupDto } from '../api/fantasyMatchupQueries';
 import MatchupCard from './MatchupCard';
 import MatchupDetailModal from './MatchupDetailModal';
 import PlayoffBracket from './PlayoffBracket';
@@ -23,26 +23,91 @@ interface Props {
   userTeamId?: number;
   seasonYear?: number;
   currentRound?: number | null;
+  playoffStartRound?: number | null;
+  numberOfRounds?: number | null;
 }
 
-function detectCurrentRoundFromSchedule(schedule: ScheduleByRoundDto[]): number {
-  const active = schedule.find((r) =>
+function detectCurrentRoundFromSchedule(
+  regularRounds: number[],
+  playoffRounds: number[],
+  regularSchedule: { roundNumber: number; matchups: FantasyMatchupDto[] }[],
+): number {
+  // First look for an unfinished regular season round
+  const activeRegular = regularSchedule.find((r) =>
     r.matchups.some((m) => m.status !== 'completed' && m.status !== 'bye'),
   );
-  return active?.roundNumber ?? schedule[schedule.length - 1].roundNumber;
+  if (activeRegular) return activeRegular.roundNumber;
+  // Then fall through to first playoff round if any exist
+  if (playoffRounds.length > 0) return playoffRounds[0];
+  // Otherwise last regular round
+  return regularRounds[regularRounds.length - 1];
 }
 
-const ScheduleTab: React.FC<Props> = ({ seasonId, userTeamId, seasonYear, currentRound }) => {
-  const { data: schedule, isLoading } = useScheduleBySeason(seasonId);
+const ScheduleTab: React.FC<Props> = ({
+  seasonId,
+  userTeamId,
+  seasonYear,
+  currentRound,
+  playoffStartRound,
+  numberOfRounds,
+}) => {
+  const { data: schedule, isLoading: scheduleLoading } = useScheduleBySeason(seasonId);
+  const { data: playoffMatchups, isLoading: playoffLoading } = usePlayoffMatchups(seasonId);
   const [selectedRound, setSelectedRound] = useState<number | null>(null);
   const [selectedMatchup, setSelectedMatchup] = useState<FantasyMatchupDto | null>(null);
 
-  // Prefer currentRound from the backend (set by lifecycle cron); fall back to schedule derivation
+  const isLoading = scheduleLoading || playoffLoading;
+
+  // All regular season round numbers from the schedule
+  const regularRounds = useMemo(
+    () => (schedule ?? []).map((r) => r.roundNumber),
+    [schedule],
+  );
+
+  // Unique playoff round numbers from fetched playoff matchups
+  const playoffRounds = useMemo(() => {
+    if (!playoffStartRound || !numberOfRounds) return [];
+    // Build the full range even if matchups aren't generated yet
+    return Array.from(
+      { length: numberOfRounds - playoffStartRound + 1 },
+      (_, i) => playoffStartRound + i,
+    );
+  }, [playoffStartRound, numberOfRounds]);
+
+  // Full ordered round list: regular + playoff
+  const allRounds = useMemo(
+    () => [...regularRounds, ...playoffRounds.filter((r) => !regularRounds.includes(r))],
+    [regularRounds, playoffRounds],
+  );
+
   const currentRoundNumber = useMemo(() => {
     if (currentRound != null) return currentRound;
-    if (schedule && schedule.length > 0) return detectCurrentRoundFromSchedule(schedule);
+    if (regularRounds.length > 0)
+      return detectCurrentRoundFromSchedule(regularRounds, playoffRounds, schedule ?? []);
     return null;
-  }, [currentRound, schedule]);
+  }, [currentRound, regularRounds, playoffRounds, schedule]);
+
+  // For two-leg ties, determine if this round is Jogo 1 or Jogo 2 within each pair.
+  // Within a twoLegPairId group, the lower roundNumber = leg 1, higher = leg 2.
+  const legNumberByMatchupId = useMemo(() => {
+    const map = new Map<string, number>();
+    if (!playoffMatchups) return map;
+
+    const byPair = new Map<string, typeof playoffMatchups>();
+    for (const matchup of playoffMatchups) {
+      if (!matchup.twoLegPairId) continue;
+      const group = byPair.get(matchup.twoLegPairId) ?? [];
+      group.push(matchup);
+      byPair.set(matchup.twoLegPairId, group);
+    }
+
+    byPair.forEach((legs) => {
+      const sorted = [...legs].sort((legA, legB) => legA.roundNumber - legB.roundNumber);
+      sorted.forEach((leg, index) => map.set(leg.id, index + 1));
+    });
+
+    return map;
+  }, [playoffMatchups]);
 
   if (!seasonId) {
     return (
@@ -68,17 +133,38 @@ const ScheduleTab: React.FC<Props> = ({ seasonId, userTeamId, seasonYear, curren
     );
   }
 
-  const rounds = schedule.map((r) => r.roundNumber);
-  const activeRound = selectedRound ?? currentRoundNumber ?? rounds[0];
-  const activeIndex = rounds.indexOf(activeRound);
+  const activeRound = selectedRound ?? currentRoundNumber ?? allRounds[0];
+  const activeIndex = allRounds.indexOf(activeRound);
+  const isPlayoffRound = playoffStartRound != null && activeRound >= playoffStartRound;
+
+  // Regular season matchups for the selected round
   const activeRoundData = schedule.find((r) => r.roundNumber === activeRound);
-
-  const isMyMatchup = (m: { homeTeamId: number | null; awayTeamId: number | null }) =>
-    userTeamId != null && (m.homeTeamId === userTeamId || m.awayTeamId === userTeamId);
-
-  const sortedMatchups = activeRoundData
-    ? [...activeRoundData.matchups].sort((a, b) => (isMyMatchup(b) ? 1 : 0) - (isMyMatchup(a) ? 1 : 0))
+  const regularMatchups = activeRoundData
+    ? [...activeRoundData.matchups].sort(
+        (a, b) => (isMyMatchup(b) ? 1 : 0) - (isMyMatchup(a) ? 1 : 0),
+      )
     : [];
+
+  // Playoff matchups for the selected round
+  const roundPlayoffMatchups = (playoffMatchups ?? []).filter(
+    (matchup) => matchup.roundNumber === activeRound,
+  );
+
+  function isMyMatchup(m: { homeTeamId: number | null; awayTeamId: number | null }) {
+    return userTeamId != null && (m.homeTeamId === userTeamId || m.awayTeamId === userTeamId);
+  }
+
+  const getStageLabel = (stage: number | null): string | null => {
+    if (stage === 1) return 'Final';
+    if (stage === 2) return 'Semifinal';
+    if (stage === 3) return 'Quartas de Final';
+    return null;
+  };
+
+  const firstStage = roundPlayoffMatchups[0]?.playoffStage ?? null;
+  const stageLabel = getStageLabel(firstStage);
+
+  const hasPlayoffMatchups = playoffMatchups && playoffMatchups.length > 0;
 
   return (
     <Box>
@@ -87,7 +173,7 @@ const ScheduleTab: React.FC<Props> = ({ seasonId, userTeamId, seasonYear, curren
         <IconButton
           size="small"
           disabled={activeIndex <= 0}
-          onClick={() => setSelectedRound(rounds[activeIndex - 1])}
+          onClick={() => setSelectedRound(allRounds[activeIndex - 1])}
         >
           <ArrowBackIosNewIcon fontSize="small" />
         </IconButton>
@@ -96,49 +182,94 @@ const ScheduleTab: React.FC<Props> = ({ seasonId, userTeamId, seasonYear, curren
           value={activeRound}
           onChange={(e) => setSelectedRound(Number(e.target.value))}
           size="small"
-          sx={{ minWidth: 160 }}
-          renderValue={(val) => (
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-              <Typography fontWeight={600}>Rodada {val}</Typography>
-              {val === currentRoundNumber && (
-                <Chip label="Atual" size="small" color="primary" sx={{ height: 18, fontSize: 11 }} />
-              )}
-            </Box>
-          )}
-        >
-          {rounds.map((r) => (
-            <MenuItem key={r} value={r}>
+          sx={{ minWidth: 180 }}
+          renderValue={(val) => {
+            const isPlayoff = playoffStartRound != null && val >= playoffStartRound;
+            return (
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                Rodada {r}
-                {r === currentRoundNumber && (
+                <Typography fontWeight={600}>Rodada {val}</Typography>
+                {isPlayoff && (
+                  <Chip label="Mata-mata" size="small" color="warning" sx={{ height: 18, fontSize: 11 }} />
+                )}
+                {val === currentRoundNumber && (
                   <Chip label="Atual" size="small" color="primary" sx={{ height: 18, fontSize: 11 }} />
                 )}
               </Box>
-            </MenuItem>
-          ))}
+            );
+          }}
+        >
+          {allRounds.map((r) => {
+            const isPlayoff = playoffStartRound != null && r >= playoffStartRound;
+            return (
+              <MenuItem key={r} value={r}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  Rodada {r}
+                  {isPlayoff && (
+                    <Chip label="Mata-mata" size="small" color="warning" sx={{ height: 18, fontSize: 11 }} />
+                  )}
+                  {r === currentRoundNumber && (
+                    <Chip label="Atual" size="small" color="primary" sx={{ height: 18, fontSize: 11 }} />
+                  )}
+                </Box>
+              </MenuItem>
+            );
+          })}
         </Select>
 
         <IconButton
           size="small"
-          disabled={activeIndex >= rounds.length - 1}
-          onClick={() => setSelectedRound(rounds[activeIndex + 1])}
+          disabled={activeIndex >= allRounds.length - 1}
+          onClick={() => setSelectedRound(allRounds[activeIndex + 1])}
         >
           <ArrowForwardIosIcon fontSize="small" />
         </IconButton>
       </Stack>
 
-      {/* Matchups */}
+      {/* Matchups area */}
       <Box mt={3}>
-        <Stack spacing={1.5}>
-          {sortedMatchups.map((matchup) => (
-            <MatchupCard
-              key={matchup.id}
-              matchup={matchup}
-              highlighted={isMyMatchup(matchup)}
-              onClick={matchup.status !== 'bye' ? () => setSelectedMatchup(matchup) : undefined}
-            />
-          ))}
-        </Stack>
+        {isPlayoffRound ? (
+          roundPlayoffMatchups.length > 0 ? (
+            <Stack spacing={1.5}>
+              {stageLabel && (
+                <Typography variant="subtitle2" fontWeight={700} color="warning.main" mb={0.5}>
+                  {stageLabel}
+                </Typography>
+              )}
+              {roundPlayoffMatchups.map((playoffMatchup) => {
+                const legNumber = legNumberByMatchupId.get(playoffMatchup.id) ?? null;
+                return (
+                  <Box key={playoffMatchup.id}>
+                    {legNumber !== null && (
+                      <Typography variant="caption" color="text.secondary" mb={0.5} display="block">
+                        Jogo {legNumber}
+                      </Typography>
+                    )}
+                    <MatchupCard
+                      matchup={playoffMatchup}
+                      highlighted={isMyMatchup(playoffMatchup)}
+                      onClick={playoffMatchup.status !== 'bye' ? () => setSelectedMatchup(playoffMatchup) : undefined}
+                    />
+                  </Box>
+                );
+              })}
+            </Stack>
+          ) : (
+            <Typography color="text.secondary" textAlign="center" py={4}>
+              Mata-mata a ser definido
+            </Typography>
+          )
+        ) : (
+          <Stack spacing={1.5}>
+            {regularMatchups.map((matchup) => (
+              <MatchupCard
+                key={matchup.id}
+                matchup={matchup}
+                highlighted={isMyMatchup(matchup)}
+                onClick={matchup.status !== 'bye' ? () => setSelectedMatchup(matchup) : undefined}
+              />
+            ))}
+          </Stack>
+        )}
       </Box>
 
       <Divider sx={{ my: 4 }} />
@@ -148,12 +279,15 @@ const ScheduleTab: React.FC<Props> = ({ seasonId, userTeamId, seasonYear, curren
       </Typography>
       <StandingsTable seasonId={seasonId} userTeamId={userTeamId} />
 
-      <Divider sx={{ my: 4 }} />
-
-      <Typography variant="h6" fontWeight={700} mb={2}>
-        Playoffs
-      </Typography>
-      <PlayoffBracket seasonId={seasonId} />
+      {hasPlayoffMatchups && (
+        <>
+          <Divider sx={{ my: 4 }} />
+          <Typography variant="h6" fontWeight={700} mb={2}>
+            Mata-mata
+          </Typography>
+          <PlayoffBracket seasonId={seasonId} seasonYear={seasonYear} />
+        </>
+      )}
 
       <MatchupDetailModal
         matchup={selectedMatchup}

--- a/src/components/SeasonStatusCard.tsx
+++ b/src/components/SeasonStatusCard.tsx
@@ -13,6 +13,7 @@ export enum LeagueStatus {
     DRAFT_DONE = 'DRAFT_DONE',
     SCHEDULED = 'SCHEDULED',
     ACTIVE = 'ACTIVE',
+    SEASON_ENDED = 'SEASON_ENDED',
     ARCHIVED = 'ARCHIVED',
   }
   
@@ -22,7 +23,8 @@ export enum LeagueStatus {
     onUpdated?: () => void;
     devEnableForceOpen?: boolean;
     refetchSeason?: () => void;
-    draftSettings?: DraftSettings;  
+    draftSettings?: DraftSettings;
+    championTeamName?: string | null;
   };
   
   function isoToDate(iso: string | null | undefined): Date | null {
@@ -75,6 +77,7 @@ const getErrorMessage = (err: unknown) => {
     | 'pre-temporada'
     | 'draft'
     | 'temporada'
+    | 'playoffs-encerrados'
     | 'pós-temporada';
   
   function computeUiPhase(season: FantasyLeagueSeason): UiPhase {
@@ -95,6 +98,8 @@ const getErrorMessage = (err: unknown) => {
         return now < kickoff ? 'pre-temporada' : 'temporada';
       case LeagueStatus.ACTIVE:
         return 'temporada';
+      case LeagueStatus.SEASON_ENDED:
+        return 'playoffs-encerrados';
       case LeagueStatus.ARCHIVED:
         return 'pós-temporada';
       default:
@@ -114,6 +119,8 @@ const getErrorMessage = (err: unknown) => {
         return 'secondary';
       case 'temporada':
         return 'success';
+      case 'playoffs-encerrados':
+        return 'warning';
       case 'pós-temporada':
         return 'primary';
     }
@@ -132,6 +139,7 @@ const getErrorMessage = (err: unknown) => {
     devEnableForceOpen = true,
     refetchSeason,
     draftSettings,
+    championTeamName,
   }: Props) {
     // Always compute a kickoff & message, even when there's no season
     const kickoff = useMemo<Date>(() => {
@@ -171,9 +179,6 @@ const getErrorMessage = (err: unknown) => {
     }
 
     const hasDraftDate = draftSettings?.draftDate ? new Date(draftSettings.draftDate) : null;
-
-    console.log(draftSettings);
-    console.log(hasDraftDate);
 
     // Helper function to render draft date information
     const renderDraftDateInfo = () => {
@@ -220,6 +225,12 @@ const getErrorMessage = (err: unknown) => {
                 {season.numberOfTeams ? ` • ${season.numberOfTeams} times` : ''}
                 {season.playoffTeams ? ` • ${season.playoffTeams}  se classificam para o mata mata` : ''}
               </Typography>
+
+              {phase === 'playoffs-encerrados' && (
+                <Typography variant="body2" fontWeight={700} color="warning.main">
+                  🏆 Campeão{championTeamName ? `: ${championTeamName}` : ''}
+                </Typography>
+              )}
 
               <Typography variant="caption" color="text.secondary">
                 {/* PT-BR UI */}

--- a/src/pages/FantasyLeague.tsx
+++ b/src/pages/FantasyLeague.tsx
@@ -124,7 +124,7 @@ const FantasyLeaguePage = ({ currentUserId }: { currentUserId: number }) => {
         <Box mt={4}>
           {selectedTab === 'draft' && <DraftTab fantasyLeague={fantasyLeague} currentUserId={currentUserId} />}
           {selectedTab === 'team' && <TeamTab seasonYear={seasonYear} seasonId={fantasyLeagueSeason?.id} userTeam={userTeam} fantasyLeague={fantasyLeague} />}
-          {selectedTab === 'schedule' && <ScheduleTab seasonId={fantasyLeagueSeason?.id} userTeamId={userTeam?.id} seasonYear={seasonYear} currentRound={fantasyLeagueSeason?.currentRound ?? null} />}
+          {selectedTab === 'schedule' && <ScheduleTab seasonId={fantasyLeagueSeason?.id} userTeamId={userTeam?.id} seasonYear={seasonYear} currentRound={fantasyLeagueSeason?.currentRound ?? null} playoffStartRound={fantasyLeagueSeason?.playoffStartRound ?? null} numberOfRounds={fantasyLeagueSeason?.numberOfRounds ?? null} />}
           {selectedTab === 'league' && <FantasyLeagueInfo currentUserId={currentUserId} fantasyLeague={fantasyLeague} />}
           {selectedTab === 'players' && (
             <Box display="flex" flexDirection="column" gap={2}>


### PR DESCRIPTION
…p, champion banner

- Rewrite PlayoffBracket as Wikipedia-style visual bracket with SVG connectors, stage columns, two-leg J1/J2/aggregate scores, bye slots, TBD slots, and champion banner
- ScheduleTab: show all rounds including playoff rounds; mata-mata chip; Jogo 1/2 labels; pass playoffStartRound and numberOfRounds from FantasyLeague page
- SeasonStatusCard: add SEASON_ENDED phase and champion display
- Add winnerId, playoffStage, twoLegPairId, playoffSeed to FantasyMatchupDto
- Add championTeamId to FantasyLeagueSeason type
- Remove leftover console.log