### PR TITLE
feat: admin squad sync tab — team roster view with per-team sync

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -50,6 +50,7 @@ const endpoints = {
   players: {
     getAll: `${API_BASE_URL}/players`,
     getFilters: `${API_BASE_URL}/players/filters/data`,
+    squad: (teamId: number) => `${API_BASE_URL}/players/squad/${teamId}`,
   },
   drafts: {
     get: (leagueId: number, season: number) => `${API_BASE_URL}/drafts/${leagueId}/${season}`,
@@ -100,6 +101,12 @@ const endpoints = {
   syncMatchInfo: {
     refreshRound: (leagueExternalId: number, seasonYear: number, roundNumber: number) =>
       `${API_BASE_URL}/sync/matches/league/${leagueExternalId}/season/${seasonYear}/round/${roundNumber}/refresh-info`,
+  },
+  syncPlayers: {
+    syncTeam: (teamExternalId: number) =>
+      `${API_BASE_URL}/sync/players/team/${teamExternalId}`,
+    syncAll: (leagueExternalId: number, seasonYear: number) =>
+      `${API_BASE_URL}/sync/players/league/${leagueExternalId}/season/${seasonYear}`,
   },
   scoringConfig: {
     getBySeason: (seasonId: string) => `${API_BASE_URL}/scoring-config/season/${seasonId}`,

--- a/src/api/playerSyncQueries.ts
+++ b/src/api/playerSyncQueries.ts
@@ -1,0 +1,50 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
+import { apiConfig } from './config';
+
+const authHeader = () => ({ Authorization: `Bearer ${localStorage.getItem('token')}` });
+
+export const useSyncTeamSquad = () => {
+  const qc = useQueryClient();
+  return useMutation<
+    { inserted: number; updated: number; cleared: number },
+    Error,
+    { teamExternalId: number; leagueExternalId: number; seasonYear: number }
+  >({
+    mutationFn: async ({ teamExternalId }) => {
+      const res = await axios.post(
+        apiConfig.endpoints.syncPlayers.syncTeam(teamExternalId),
+        {},
+        { headers: authHeader() },
+      );
+      return res.data;
+    },
+    onSuccess: (_data, { leagueExternalId, seasonYear }) => {
+      qc.invalidateQueries({ queryKey: ['playerFilters', leagueExternalId, seasonYear] });
+      // invalidate the specific team's roster cache
+      qc.invalidateQueries({ queryKey: ['squadRoster'] });
+    },
+  });
+};
+
+export const useSyncAllSquads = () => {
+  const qc = useQueryClient();
+  return useMutation<
+    { teams: number; inserted: number; updated: number; cleared: number },
+    Error,
+    { leagueExternalId: number; seasonYear: number }
+  >({
+    mutationFn: async ({ leagueExternalId, seasonYear }) => {
+      const res = await axios.post(
+        apiConfig.endpoints.syncPlayers.syncAll(leagueExternalId, seasonYear),
+        {},
+        { headers: authHeader() },
+      );
+      return res.data;
+    },
+    onSuccess: (_data, { leagueExternalId, seasonYear }) => {
+      qc.invalidateQueries({ queryKey: ['playerFilters', leagueExternalId, seasonYear] });
+      qc.invalidateQueries({ queryKey: ['squadRoster'] }); // broad invalidate — refreshes all open team rosters
+    },
+  });
+};

--- a/src/pages/admin/AdminRoundFlowPage.tsx
+++ b/src/pages/admin/AdminRoundFlowPage.tsx
@@ -39,6 +39,7 @@ import {
   useUpdateRoundFlow,
 } from '../../api/roundFlowQueries';
 import RoundGamesTab from './RoundGamesTab';
+import SquadSyncTab from './SquadSyncTab';
 
 const STATUS_COLORS: Record<RoundFlowStatus, 'default' | 'success' | 'info' | 'warning' | 'secondary' | 'error'> = {
   PENDING: 'default',
@@ -73,9 +74,11 @@ const AdminRoundFlowPage: React.FC = () => {
       <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 3, borderBottom: 1, borderColor: 'divider' }}>
         <Tab label="Fluxo de Rodada" />
         <Tab label="Jogos da Rodada" />
+        <Tab label="Elencos" />
       </Tabs>
       {tab === 0 && <RoundFlowTab />}
       {tab === 1 && <RoundGamesTab />}
+      {tab === 2 && <SquadSyncTab />}
     </Box>
   );
 };

--- a/src/pages/admin/SquadSyncTab.tsx
+++ b/src/pages/admin/SquadSyncTab.tsx
@@ -1,0 +1,259 @@
+import React, { useState } from 'react';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  IconButton,
+  Snackbar,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import SyncIcon from '@mui/icons-material/Sync';
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+import { apiConfig } from '../../api/config';
+import { useSyncAllSquads, useSyncTeamSquad } from '../../api/playerSyncQueries';
+
+const authHeader = () => ({ Authorization: `Bearer ${localStorage.getItem('token')}` });
+
+interface TeamFilter {
+  id: number;
+  name: string;
+  externalId: number;
+  lastSquadSyncAt: string | null;
+}
+
+interface RosterPlayer {
+  id: number;
+  name: string;
+  position: string;
+  number: number | null;
+  age: number | null;
+}
+
+function formatSyncDate(iso: string | null): string {
+  if (!iso) return 'Nunca';
+  return new Date(iso).toLocaleString('pt-BR', { timeZone: 'America/Sao_Paulo' });
+}
+
+// ─── Team accordion row ───────────────────────────────────────────────────────
+
+const TeamRow: React.FC<{
+  team: TeamFilter;
+  leagueId: number;
+  seasonYear: number;
+  onMessage: (msg: string) => void;
+}> = ({ team, leagueId, seasonYear, onMessage }) => {
+  const [expanded, setExpanded] = useState(false);
+  const syncTeam = useSyncTeamSquad();
+
+  const { data: roster = [], isLoading: rosterLoading } = useQuery<RosterPlayer[]>({
+    queryKey: ['squadRoster', team.id],
+    queryFn: async () => {
+      const res = await axios.get(apiConfig.endpoints.players.squad(team.id), {
+        headers: authHeader(),
+      });
+      return res.data;
+    },
+    enabled: expanded,
+    staleTime: 0,
+  });
+
+  const handleSync = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    syncTeam.mutate(
+      { teamExternalId: team.externalId, leagueExternalId: leagueId, seasonYear },
+      {
+        onSuccess: (d) =>
+          onMessage(
+            `${team.name}: ${d.inserted} inserido(s), ${d.updated} atualizado(s)`,
+          ),
+        onError: (err) => onMessage(`Erro: ${err.message}`),
+      },
+    );
+  };
+
+  const players = roster;
+
+  return (
+    <Accordion expanded={expanded} onChange={(_, v) => setExpanded(v)}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Stack direction="row" alignItems="center" spacing={2} sx={{ width: '100%', pr: 1 }}>
+          <Typography fontWeight="bold" sx={{ minWidth: 180 }}>
+            {team.name}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            Última atualização: {formatSyncDate(team.lastSquadSyncAt)}
+          </Typography>
+          <Box sx={{ flexGrow: 1 }} />
+          <Tooltip title="Sincronizar elenco deste time">
+            <span>
+              <IconButton
+                size="small"
+                disabled={syncTeam.isPending}
+                onClick={handleSync}
+              >
+                {syncTeam.isPending ? <CircularProgress size={16} /> : <SyncIcon fontSize="small" />}
+              </IconButton>
+            </span>
+          </Tooltip>
+        </Stack>
+      </AccordionSummary>
+      <AccordionDetails sx={{ p: 0 }}>
+        {rosterLoading ? (
+          <Box sx={{ p: 2, display: 'flex', justifyContent: 'center' }}>
+            <CircularProgress size={20} />
+          </Box>
+        ) : players.length === 0 ? (
+          <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
+            Nenhum jogador encontrado — sincronize o elenco.
+          </Typography>
+        ) : (
+          <TableContainer>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>#</TableCell>
+                  <TableCell>Nome</TableCell>
+                  <TableCell>Posição</TableCell>
+                  <TableCell>Idade</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {players.map((p) => (
+                  <TableRow key={p.id} hover>
+                    <TableCell>{p.number ?? '—'}</TableCell>
+                    <TableCell>{p.name}</TableCell>
+                    <TableCell>{p.position}</TableCell>
+                    <TableCell>{p.age ?? '—'}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </AccordionDetails>
+    </Accordion>
+  );
+};
+
+// ─── Main tab ─────────────────────────────────────────────────────────────────
+
+const SquadSyncTab: React.FC = () => {
+  const [leagueId, setLeagueId] = useState('71');
+  const [seasonYear, setSeasonYear] = useState(String(new Date().getFullYear()));
+  const [snack, setSnack] = useState<string | null>(null);
+
+  const leagueExternalId = Number(leagueId) || undefined;
+  const year = Number(seasonYear) || undefined;
+
+  const { data: filtersData, isLoading: teamsLoading } = useQuery<{ teams: TeamFilter[] }>({
+    queryKey: ['playerFilters', leagueExternalId, year],
+    queryFn: async () => {
+      const res = await axios.get(apiConfig.endpoints.players.getFilters, {
+        params: { leagueId: leagueExternalId, seasonYear: year },
+        headers: authHeader(),
+      });
+      return res.data;
+    },
+    enabled: !!leagueExternalId && !!year,
+    staleTime: 0,
+  });
+
+  const teams = (filtersData?.teams ?? []).sort((a, b) => a.name.localeCompare(b.name));
+  const syncAll = useSyncAllSquads();
+
+  const handleSyncAll = () => {
+    if (!leagueExternalId || !year) return;
+    syncAll.mutate(
+      { leagueExternalId, seasonYear: year },
+      {
+        onSuccess: (d) =>
+          setSnack(
+            `${d.teams} time(s) — ${d.inserted} inserido(s), ${d.updated} atualizado(s), ${d.cleared} saíram da liga`,
+          ),
+        onError: (err) => setSnack(`Erro: ${err.message}`),
+      },
+    );
+  };
+
+  return (
+    <Box>
+      {/* Controls */}
+      <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 3 }}>
+        <TextField
+          label="ID Externo da Liga"
+          type="number"
+          value={leagueId}
+          onChange={(e) => setLeagueId(e.target.value)}
+          size="small"
+          sx={{ width: 160 }}
+          helperText="71 = Brasileirão"
+        />
+        <TextField
+          label="Ano da Temporada"
+          type="number"
+          value={seasonYear}
+          onChange={(e) => setSeasonYear(e.target.value)}
+          size="small"
+          sx={{ width: 120 }}
+        />
+        <Button
+          variant="contained"
+          startIcon={syncAll.isPending ? <CircularProgress size={16} color="inherit" /> : <SyncIcon />}
+          disabled={!leagueExternalId || !year || syncAll.isPending}
+          onClick={handleSyncAll}
+        >
+          Sincronizar Todos os Elencos
+        </Button>
+      </Stack>
+
+      {/* Teams list */}
+      {teamsLoading ? (
+        <CircularProgress size={24} />
+      ) : teams.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          Nenhum time encontrado para esta liga/temporada.
+        </Typography>
+      ) : (
+        <Box>
+          {teams.map((team) => (
+            <TeamRow
+              key={team.id}
+              team={team}
+              leagueId={leagueExternalId ?? 0}
+              seasonYear={year ?? 0}
+              onMessage={setSnack}
+            />
+          ))}
+        </Box>
+      )}
+
+      <Snackbar
+        open={snack != null}
+        autoHideDuration={5000}
+        onClose={() => setSnack(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity="info" onClose={() => setSnack(null)} sx={{ width: '100%' }}>
+          {snack}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+};
+
+export default SquadSyncTab;


### PR DESCRIPTION
- New SquadSyncTab: accordion list of all teams for a league/season, each expandable to show current DB roster (name, position, #, age)
- Per-team sync button + Sincronizar Todos os Elencos bulk button
- Shows last sync timestamp per team (Nunca if never synced)
- Add useSyncTeamSquad and useSyncAllSquads mutations
- Add syncPlayers endpoints to config