### PR TITLE
feat: settings lock, Pontuações tab, and Rodada tab

### DIFF
--- a/src/components/DraftSettingsForm.tsx
+++ b/src/components/DraftSettingsForm.tsx
@@ -1,32 +1,38 @@
 import React, { useState } from 'react';
 import {
-  Box,
-  Typography,
-  Select,
-  MenuItem,
-  TextField,
-  FormControl,
-  Button,
-  Snackbar,
   Alert,
+  Box,
+  Button,
+  FormControl,
+  MenuItem,
+  Select,
+  Snackbar,
+  TextField,
+  Typography,
 } from '@mui/material';
-import { DraftSettings, useUpdateDraftSettings } from '../api/useDraftSettingsMutations'; // <- create this hook
+import { DraftSettings, useUpdateDraftSettings } from '../api/useDraftSettingsMutations';
+
+const DRAFT_LOCKED_STATUSES = [
+  'DRAFT_DONE', 'SCHEDULED', 'ACTIVE', 'SEASON_ENDED', 'ARCHIVED',
+];
 
 interface Props {
   values: DraftSettings;
   onChange: (field: string, value: any) => void;
   id: number;
   refetchDraftSettings: () => void;
+  seasonStatus?: string;
 }
-
 
 const DraftSettingsForm: React.FC<Props> = ({
   values,
   onChange,
   id,
   refetchDraftSettings,
+  seasonStatus,
 }) => {
   const [openSnackbar, setOpenSnackbar] = useState(false);
+  const isLocked = !!seasonStatus && DRAFT_LOCKED_STATUSES.includes(seasonStatus);
 
   const updateDraftSettings = useUpdateDraftSettings({
     onSuccess: () => {
@@ -37,6 +43,11 @@ const DraftSettingsForm: React.FC<Props> = ({
 
   return (
     <>
+      {isLocked && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          Configurações de draft bloqueadas — o draft já foi realizado.
+        </Alert>
+      )}
       {/* Draft Type */}
       <Box>
         <Typography fontWeight={600}>Tipo de Draft</Typography>
@@ -44,6 +55,7 @@ const DraftSettingsForm: React.FC<Props> = ({
           <Select
             value={values.draftType ?? ''}
             onChange={(e) => onChange('draftType', e.target.value)}
+            disabled={isLocked}
           >
             <MenuItem value="snake">Snake</MenuItem>
             <MenuItem value="linear">Linear</MenuItem>
@@ -58,6 +70,7 @@ const DraftSettingsForm: React.FC<Props> = ({
           <Select
             value={values.pickTimer ?? ''}
             onChange={(e) => onChange('pickTimer', e.target.value)}
+            disabled={isLocked}
           >
             <MenuItem value={30}>30 segundos</MenuItem>
             <MenuItem value={60}>60 segundos</MenuItem>
@@ -104,7 +117,7 @@ const DraftSettingsForm: React.FC<Props> = ({
               updates: values,
             })
           }
-          disabled={updateDraftSettings.isPending}
+          disabled={updateDraftSettings.isPending || isLocked}
         >
           Salvar
         </Button>

--- a/src/components/FantasyLeagueSeasonForm.tsx
+++ b/src/components/FantasyLeagueSeasonForm.tsx
@@ -1,26 +1,34 @@
 import React, { useMemo, useState } from 'react';
 import {
+  Alert,
   Box,
-  Typography,
-  Select,
-  MenuItem,
-  FormControl,
-  RadioGroup,
-  FormControlLabel,
-  Radio,
   Button,
+  FormControl,
+  FormControlLabel,
+  MenuItem,
+  Radio,
+  RadioGroup,
+  Select,
+  Snackbar,
+  Typography,
 } from '@mui/material';
 import { useUpdateFantasyLeagueSeason } from '../api/fantasyLeagueSeasonsMutation';
-import { Snackbar, Alert } from '@mui/material';
+
+const SEASON_LOCKED_STATUSES = [
+  'DRAFT_SCHEDULED', 'DRAFT_LIVE', 'DRAFT_DONE',
+  'SCHEDULED', 'ACTIVE', 'SEASON_ENDED', 'ARCHIVED',
+];
 
 interface Props {
   values: any;
   onChange: (field: string, value: any) => void;
   id: any;
   refetchFantasyLeagueSeason: () => void;
+  seasonStatus?: string;
 }
 
-const FantasyLeagueSeasonForm: React.FC<Props> = ({ values, onChange, id, refetchFantasyLeagueSeason }) => {
+const FantasyLeagueSeasonForm: React.FC<Props> = ({ values, onChange, id, refetchFantasyLeagueSeason, seasonStatus }) => {
+  const isLocked = !!seasonStatus && SEASON_LOCKED_STATUSES.includes(seasonStatus);
   const [openSnackbar, setOpenSnackbar] = useState(false);
   const tradeDeadlineOptions = useMemo(() => {
     const start = Math.max(1, values.numberOfRounds - 8);
@@ -37,6 +45,11 @@ const FantasyLeagueSeasonForm: React.FC<Props> = ({ values, onChange, id, refetc
 
   return (
     <>
+      {isLocked && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          Configurações bloqueadas — o draft já foi agendado.
+        </Alert>
+      )}
       {/* Número de Times */}
       <Box>
         <Typography fontWeight={600}>Número de Times</Typography>
@@ -44,6 +57,7 @@ const FantasyLeagueSeasonForm: React.FC<Props> = ({ values, onChange, id, refetc
           <Select
             value={values.numberOfTeams ?? ''}
             onChange={(e) => onChange('numberOfTeams', e.target.value)}
+            disabled={isLocked}
           >
             {Array.from({ length: 13 }, (_, i) => i + 8).map((n) => (
               <MenuItem key={n} value={n}>
@@ -64,6 +78,7 @@ const FantasyLeagueSeasonForm: React.FC<Props> = ({ values, onChange, id, refetc
           <Select
             value={values.tradeReviewDays ?? ''}
             onChange={(e) => onChange('tradeReviewDays', e.target.value)}
+            disabled={isLocked}
           >
             {[0, 1, 2, 3].map((day) => (
               <MenuItem key={day} value={day}>
@@ -81,6 +96,7 @@ const FantasyLeagueSeasonForm: React.FC<Props> = ({ values, onChange, id, refetc
           <Select
             value={values.numberOfRounds ?? ''}
             onChange={(e) => onChange('numberOfRounds', e.target.value)}
+            disabled={isLocked}
           >
             {Array.from({ length: 20 }, (_, i) => 19 + i).map((val) => (
               <MenuItem key={val} value={val}>
@@ -101,6 +117,7 @@ const FantasyLeagueSeasonForm: React.FC<Props> = ({ values, onChange, id, refetc
           <Select
             value={values.tradeDeadlineRound ?? ''}
             onChange={(e) => onChange('tradeDeadlineRound', e.target.value)}
+            disabled={isLocked}
           >
             <MenuItem value="">Sem limite</MenuItem>
             {tradeDeadlineOptions.map((round) => (
@@ -119,6 +136,7 @@ const FantasyLeagueSeasonForm: React.FC<Props> = ({ values, onChange, id, refetc
           <Select
             value={values.playoffTeams ?? ''}
             onChange={(e) => onChange('playoffTeams', e.target.value)}
+            disabled={isLocked}
           >
             {[4, 6, 7, 8].map((n) => (
               <MenuItem key={n} value={n}>
@@ -136,6 +154,7 @@ const FantasyLeagueSeasonForm: React.FC<Props> = ({ values, onChange, id, refetc
           <Select
             value={values.irSlots ?? ''}
             onChange={(e) => onChange('irSlots', e.target.value)}
+            disabled={isLocked}
           >
             {Array.from({ length: 9 }, (_, i) => (
               <MenuItem key={i} value={i}>
@@ -152,6 +171,7 @@ const FantasyLeagueSeasonForm: React.FC<Props> = ({ values, onChange, id, refetc
         <RadioGroup
           value={values.playoffFormat ?? ''}
           onChange={(e) => onChange('playoffFormat', e.target.value)}
+          aria-disabled={isLocked}
         >
           <FormControlLabel
             value="single_game"
@@ -181,7 +201,7 @@ const FantasyLeagueSeasonForm: React.FC<Props> = ({ values, onChange, id, refetc
           <Button
             variant="contained"
             onClick={() => updateFantasyLeagueSeason.mutate({ id, updates: values })}
-            disabled={updateFantasyLeagueSeason.isPending}
+            disabled={updateFantasyLeagueSeason.isPending || isLocked}
           >
             Salvar
           </Button>

--- a/src/components/FantasyLeagueSettingsModal.tsx
+++ b/src/components/FantasyLeagueSettingsModal.tsx
@@ -113,6 +113,7 @@ const FantasyLeagueSettingsModal: React.FC<Props> = ({ open, onClose, fantasyLea
             }
             id={fantasyLeagueSeason?.id!}
             refetchFantasyLeagueSeason={refetchFantasyLeagueSeason}
+            seasonStatus={fantasyLeagueSeason?.status}
           />
         );
       case 'roster':
@@ -125,6 +126,7 @@ const FantasyLeagueSettingsModal: React.FC<Props> = ({ open, onClose, fantasyLea
               id={draftSettings?.id!}
               refetchRosterSettings={refetchRosterSettings}
               refetchDraftSettings={refetchDraftSettings}
+              seasonStatus={fantasyLeagueSeason?.status}
             />
           );
       case 'draft':
@@ -136,6 +138,7 @@ const FantasyLeagueSettingsModal: React.FC<Props> = ({ open, onClose, fantasyLea
             }
             id={draftSettings?.id!}
             refetchDraftSettings={refetchDraftSettings}
+            seasonStatus={fantasyLeagueSeason?.status}
           />
         );
       case 'scoring':

--- a/src/components/FantasyLeagueTabs.tsx
+++ b/src/components/FantasyLeagueTabs.tsx
@@ -5,6 +5,7 @@ const tabs = [
   { label: 'Draft', key: 'draft' },
   { label: 'Times', key: 'team' },
   { label: 'Tabela', key: 'schedule' },
+  { label: 'Rodada', key: 'rodada' },
   { label: 'Liga', key: 'league' },
   { label: 'Jogadores', key: 'players' },
   { label: 'Trocas', key: 'trades' },

--- a/src/components/MatchupDetailModal.tsx
+++ b/src/components/MatchupDetailModal.tsx
@@ -19,14 +19,6 @@ import { getOpponentForTeam, formatMatchTime, OpponentInfo } from '../utils/matc
 import { usePointsByRound } from '../api/playerFantasyPointsQueries';
 import PlayerStatsModal from './PlayerStatsModal';
 
-interface Props {
-  matchup: FantasyMatchupDto | null;
-  onClose: () => void;
-  userTeamId?: number;
-  seasonYear?: number;
-  seasonId?: string;
-}
-
 const STATUS_LABELS: Record<string, string> = {
   scheduled: 'Agendado',
   live: 'Ao Vivo',
@@ -39,7 +31,7 @@ const STATUS_COLORS: Record<string, 'default' | 'warning' | 'success'> = {
   completed: 'success',
 };
 
-// ─── Live/Scheduled roster row (uses current roster) ────────────────────────
+// ─── Live/Scheduled roster row ───────────────────────────────────────────────
 
 function SlotRow({
   slot,
@@ -73,15 +65,11 @@ function SlotRow({
         <>
           <Avatar src={slot.player.photo} sx={{ width: 24, height: 24 }} />
           <Box flex={1}>
-            <Typography variant="body2" noWrap>
-              {slot.player.name}
-            </Typography>
+            <Typography variant="body2" noWrap>{slot.player.name}</Typography>
             {opponentInfo && (
               <Typography variant="caption" color="text.disabled" noWrap>
                 x {opponentInfo.code} ({opponentInfo.isHome ? 'C' : 'V'})
-                {formatMatchTime(opponentInfo.matchDate) && (
-                  <> · {formatMatchTime(opponentInfo.matchDate)}</>
-                )}
+                {formatMatchTime(opponentInfo.matchDate) && <> · {formatMatchTime(opponentInfo.matchDate)}</>}
               </Typography>
             )}
           </Box>
@@ -92,23 +80,15 @@ function SlotRow({
           )}
         </>
       ) : (
-        <Typography variant="body2" color="text.disabled">
-          Vazio
-        </Typography>
+        <Typography variant="body2" color="text.disabled">Vazio</Typography>
       )}
     </Box>
   );
 }
 
 function RosterColumn({
-  teamName,
-  teamId,
-  seasonYear,
-  realMatches,
-  pointsMap,
-  onPlayerClick,
+  teamId, seasonYear, realMatches, pointsMap, onPlayerClick,
 }: {
-  teamName: string | null;
   teamId: number | null;
   seasonYear?: number;
   realMatches?: RealMatchDto[];
@@ -116,38 +96,23 @@ function RosterColumn({
   onPlayerClick?: (slot: Slot, opponentInfo: OpponentInfo | null) => void;
 }) {
   const { data: slots, isLoading } = useRoster({ userTeamId: teamId ?? undefined, seasonYear });
-
   const starters = slots ? [...slots].filter((s) => s.slotType === 'starter').sort((a, b) => a.index - b.index) : [];
   const bench = slots ? [...slots].filter((s) => s.slotType === 'bench').sort((a, b) => a.index - b.index) : [];
 
   return (
     <Box>
-      <Typography fontWeight={700} variant="subtitle1" mb={1} noWrap>
-        {teamName ?? 'Ghost'}
-      </Typography>
-
       {isLoading ? (
-        <Box display="flex" justifyContent="center" py={4}>
-          <CircularProgress size={24} />
-        </Box>
+        <Box display="flex" justifyContent="center" py={4}><CircularProgress size={24} /></Box>
       ) : !teamId ? (
-        <Typography variant="body2" color="text.disabled">
-          Time fantasma
-        </Typography>
+        <Typography variant="body2" color="text.disabled">Time fantasma</Typography>
       ) : (
         <>
-          <Typography variant="caption" color="text.secondary" fontWeight={600}>
-            Titulares
-          </Typography>
+          <Typography variant="caption" color="text.secondary" fontWeight={600}>Titulares</Typography>
           {starters.map((slot) => (
             <SlotRow key={slot.index} slot={slot} realMatches={realMatches} pointsMap={pointsMap} onPlayerClick={onPlayerClick} />
           ))}
-
           <Divider sx={{ my: 1 }} />
-
-          <Typography variant="caption" color="text.secondary" fontWeight={600}>
-            Reservas
-          </Typography>
+          <Typography variant="caption" color="text.secondary" fontWeight={600}>Reservas</Typography>
           {bench.map((slot) => (
             <SlotRow key={slot.index} slot={slot} realMatches={realMatches} pointsMap={pointsMap} onPlayerClick={onPlayerClick} />
           ))}
@@ -157,12 +122,10 @@ function RosterColumn({
   );
 }
 
-// ─── Historical snapshot row (uses frozen roster snapshot) ──────────────────
+// ─── Historical snapshot row ─────────────────────────────────────────────────
 
 function SnapshotSlotRow({
-  slot,
-  realMatches,
-  onPlayerClick,
+  slot, realMatches, onPlayerClick,
 }: {
   slot: SnapshotSlotDto;
   realMatches?: RealMatchDto[];
@@ -186,40 +149,27 @@ function SnapshotSlotRow({
         <>
           <Avatar src={slot.playerPhoto ?? undefined} sx={{ width: 24, height: 24 }} />
           <Box flex={1}>
-            <Typography variant="body2" noWrap>
-              {slot.playerName}
-            </Typography>
+            <Typography variant="body2" noWrap>{slot.playerName}</Typography>
             {opponentInfo && (
               <Typography variant="caption" color="text.disabled" noWrap>
                 x {opponentInfo.code} ({opponentInfo.isHome ? 'C' : 'V'})
               </Typography>
             )}
           </Box>
-          <Typography
-            variant="body2"
-            fontWeight={700}
-            color={slot.points >= 0 ? 'success.main' : 'error.main'}
-            sx={{ minWidth: 36, textAlign: 'right' }}
-          >
+          <Typography variant="body2" fontWeight={700} color={slot.points >= 0 ? 'success.main' : 'error.main'} sx={{ minWidth: 36, textAlign: 'right' }}>
             {slot.points.toFixed(1)}
           </Typography>
         </>
       ) : (
-        <Typography variant="body2" color="text.disabled">
-          Vazio
-        </Typography>
+        <Typography variant="body2" color="text.disabled">Vazio</Typography>
       )}
     </Box>
   );
 }
 
 function SnapshotColumn({
-  teamName,
-  slots,
-  realMatches,
-  onPlayerClick,
+  slots, realMatches, onPlayerClick,
 }: {
-  teamName: string | null;
   slots: SnapshotSlotDto[];
   realMatches?: RealMatchDto[];
   onPlayerClick?: (playerId: number, playerName: string | null, opponentInfo: OpponentInfo | null) => void;
@@ -229,23 +179,14 @@ function SnapshotColumn({
 
   return (
     <Box>
-      <Typography fontWeight={700} variant="subtitle1" mb={1} noWrap>
-        {teamName ?? 'Ghost'}
-      </Typography>
-
-      <Typography variant="caption" color="text.secondary" fontWeight={600}>
-        Titulares
-      </Typography>
+      <Typography variant="caption" color="text.secondary" fontWeight={600}>Titulares</Typography>
       {starters.map((slot) => (
         <SnapshotSlotRow key={slot.slotIndex} slot={slot} realMatches={realMatches} onPlayerClick={onPlayerClick} />
       ))}
-
       {bench.length > 0 && (
         <>
           <Divider sx={{ my: 1 }} />
-          <Typography variant="caption" color="text.secondary" fontWeight={600}>
-            Reservas
-          </Typography>
+          <Typography variant="caption" color="text.secondary" fontWeight={600}>Reservas</Typography>
           {bench.map((slot) => (
             <SnapshotSlotRow key={slot.slotIndex} slot={slot} realMatches={realMatches} onPlayerClick={onPlayerClick} />
           ))}
@@ -255,131 +196,147 @@ function SnapshotColumn({
   );
 }
 
-// ─── Main modal ─────────────────────────────────────────────────────────────
+// ─── MatchupDetail (reusable inline content) ─────────────────────────────────
 
-const MatchupDetailModal: React.FC<Props> = ({ matchup, onClose, userTeamId, seasonYear, seasonId }) => {
-  const isCompleted = matchup?.status === 'completed';
+export interface MatchupDetailProps {
+  matchup: FantasyMatchupDto;
+  userTeamId?: number;
+  seasonYear?: number;
+  seasonId?: string;
+}
 
-  const { data: realMatches } = useRealMatchesByRound(seasonYear, matchup?.roundNumber ?? undefined);
+export const MatchupDetail: React.FC<MatchupDetailProps> = ({ matchup, userTeamId, seasonYear, seasonId }) => {
+  const isCompleted = matchup.status === 'completed';
+
+  const { data: realMatches } = useRealMatchesByRound(seasonYear, matchup.roundNumber);
   const { data: pointsMap } = usePointsByRound(
     isCompleted ? undefined : seasonId,
-    matchup?.roundNumber ?? undefined,
+    matchup.roundNumber,
   );
   const { data: snapshotData, isLoading: snapshotLoading } = useMatchupRosterSnapshot(
-    isCompleted ? matchup?.id : undefined,
+    isCompleted ? matchup.id : undefined,
   );
 
   const [statsSlot, setStatsSlot] = useState<{ id: number; name?: string; photo?: string; opponentInfo?: OpponentInfo | null } | null>(null);
 
-  const userIsAway = userTeamId != null && matchup?.awayTeamId === userTeamId;
+  const leftTeamId = matchup.homeTeamId;
+  const rightTeamId = matchup.awayTeamId;
 
-  const leftTeamId = userIsAway ? matchup!.awayTeamId : matchup?.homeTeamId ?? null;
-  const leftTeamName = userIsAway ? matchup!.awayTeamName : matchup?.homeTeamName ?? null;
-  const leftScore = userIsAway ? matchup!.awayScore : matchup?.homeScore ?? null;
-
-  const rightTeamId = userIsAway ? matchup!.homeTeamId : matchup?.awayTeamId ?? null;
-  const rightTeamName = userIsAway ? matchup!.homeTeamName : matchup?.awayTeamName ?? null;
-  const rightScore = userIsAway ? matchup!.homeScore : matchup?.awayScore ?? null;
-
-  const leftSnapshot = userIsAway ? snapshotData?.awayTeam : snapshotData?.homeTeam;
-  const rightSnapshot = userIsAway ? snapshotData?.homeTeam : snapshotData?.awayTeam;
-
-  const statusLabel = matchup ? (STATUS_LABELS[matchup.status] ?? matchup.status) : '';
-  const statusColor = matchup ? (STATUS_COLORS[matchup.status] ?? 'default') : 'default';
+  const leftSnapshot = snapshotData?.homeTeam;
+  const rightSnapshot = snapshotData?.awayTeam;
 
   return (
-    <Dialog open={!!matchup} onClose={onClose} fullWidth maxWidth="md">
-      <DialogTitle>
-        <Box display="flex" alignItems="center" justifyContent="space-between">
-          <Box display="flex" alignItems="center" gap={1}>
-            <Typography fontWeight={700}>Rodada {matchup?.roundNumber}</Typography>
-            <Chip label={statusLabel} size="small" color={statusColor} />
-          </Box>
-          <IconButton size="small" onClick={onClose}>
-            <CloseIcon fontSize="small" />
-          </IconButton>
-        </Box>
-      </DialogTitle>
+    <>
 
-      <DialogContent>
-        {/* Score row */}
-        <Box display="flex" alignItems="center" justifyContent="center" gap={2} mb={3}>
-          <Typography variant="h6" fontWeight={700} sx={{ flex: 1, textAlign: 'right' }} noWrap>
-            {leftTeamName ?? 'Ghost'}
-          </Typography>
-          <Typography variant="h5" fontWeight={800} color="text.secondary" sx={{ minWidth: 80, textAlign: 'center' }}>
-            {leftScore != null ? Number(leftScore).toFixed(1) : '—'} – {rightScore != null ? Number(rightScore).toFixed(1) : '—'}
-          </Typography>
-          <Typography variant="h6" fontWeight={700} sx={{ flex: 1 }} noWrap>
-            {rightTeamName ?? 'Ghost'}
-          </Typography>
-        </Box>
-
-        <Divider sx={{ mb: 2 }} />
-
-        {/* Side-by-side rosters */}
-        {isCompleted ? (
-          snapshotLoading ? (
-            <Box display="flex" justifyContent="center" py={4}>
-              <CircularProgress size={28} />
-            </Box>
-          ) : (
-            <Box display="flex" gap={3} flexWrap="wrap">
-              <Box flex={1} minWidth={200}>
-                <SnapshotColumn
-                  teamName={leftTeamName}
-                  slots={leftSnapshot?.slots ?? []}
-                  realMatches={realMatches}
-                  onPlayerClick={(id, name, opp) => setStatsSlot({ id, name: name ?? undefined, opponentInfo: opp })}
-                />
-              </Box>
-              <Box flex={1} minWidth={200}>
-                <SnapshotColumn
-                  teamName={rightTeamName}
-                  slots={rightSnapshot?.slots ?? []}
-                  realMatches={realMatches}
-                  onPlayerClick={(id, name, opp) => setStatsSlot({ id, name: name ?? undefined, opponentInfo: opp })}
-                />
-              </Box>
-            </Box>
-          )
+      {/* Side-by-side rosters */}
+      {isCompleted ? (
+        snapshotLoading ? (
+          <Box display="flex" justifyContent="center" py={4}><CircularProgress size={28} /></Box>
         ) : (
           <Box display="flex" gap={3} flexWrap="wrap">
             <Box flex={1} minWidth={200}>
-              <RosterColumn
-                teamName={leftTeamName}
-                teamId={leftTeamId}
-                seasonYear={seasonYear}
+              <SnapshotColumn
+                slots={leftSnapshot?.slots ?? []}
                 realMatches={realMatches}
-                pointsMap={pointsMap}
-                onPlayerClick={(slot, opp) => setStatsSlot({ id: slot.player?.id, name: slot.player?.name, photo: slot.player?.photo, opponentInfo: opp })}
+                onPlayerClick={(id, name, opp) => setStatsSlot({ id, name: name ?? undefined, opponentInfo: opp })}
               />
             </Box>
             <Box flex={1} minWidth={200}>
-              <RosterColumn
-                teamName={rightTeamName}
-                teamId={rightTeamId}
-                seasonYear={seasonYear}
+              <SnapshotColumn
+                slots={rightSnapshot?.slots ?? []}
                 realMatches={realMatches}
-                pointsMap={pointsMap}
-                onPlayerClick={(slot, opp) => setStatsSlot({ id: slot.player?.id, name: slot.player?.name, photo: slot.player?.photo, opponentInfo: opp })}
+                onPlayerClick={(id, name, opp) => setStatsSlot({ id, name: name ?? undefined, opponentInfo: opp })}
               />
             </Box>
           </Box>
-        )}
-      </DialogContent>
+        )
+      ) : (
+        <Box display="flex" gap={3} flexWrap="wrap">
+          <Box flex={1} minWidth={200}>
+            <RosterColumn
+              teamId={leftTeamId}
+              seasonYear={seasonYear}
+              realMatches={realMatches}
+              pointsMap={pointsMap}
+              onPlayerClick={(slot, opp) => setStatsSlot({ id: slot.player?.id, name: slot.player?.name, photo: slot.player?.photo, opponentInfo: opp })}
+            />
+          </Box>
+          <Box flex={1} minWidth={200}>
+            <RosterColumn
+              teamId={rightTeamId}
+              seasonYear={seasonYear}
+              realMatches={realMatches}
+              pointsMap={pointsMap}
+              onPlayerClick={(slot, opp) => setStatsSlot({ id: slot.player?.id, name: slot.player?.name, photo: slot.player?.photo, opponentInfo: opp })}
+            />
+          </Box>
+        </Box>
+      )}
 
       <PlayerStatsModal
         playerId={statsSlot?.id ?? null}
         playerName={statsSlot?.name}
         playerPhoto={statsSlot?.photo}
         seasonId={seasonId}
-        roundFilter={matchup?.roundNumber ?? undefined}
+        roundFilter={matchup.roundNumber}
         opponentInfo={statsSlot?.opponentInfo}
         onClose={() => setStatsSlot(null)}
       />
-    </Dialog>
+    </>
   );
 };
+
+// ─── Modal wrapper (backward compat) ─────────────────────────────────────────
+
+interface ModalProps {
+  matchup: FantasyMatchupDto | null;
+  onClose: () => void;
+  userTeamId?: number;
+  seasonYear?: number;
+  seasonId?: string;
+}
+
+const MatchupDetailModal: React.FC<ModalProps> = ({ matchup, onClose, userTeamId, seasonYear, seasonId }) => (
+  <Dialog open={!!matchup} onClose={onClose} fullWidth maxWidth="md">
+    <DialogTitle>
+      <Box display="flex" alignItems="center" justifyContent="space-between">
+        <Box display="flex" alignItems="center" gap={1}>
+          <Typography fontWeight={700}>Rodada {matchup?.roundNumber}</Typography>
+          {matchup && (
+            <Chip
+              label={STATUS_LABELS[matchup.status] ?? matchup.status}
+              size="small"
+              color={(STATUS_COLORS[matchup.status] ?? 'default') as any}
+            />
+          )}
+        </Box>
+        <IconButton size="small" onClick={onClose}><CloseIcon fontSize="small" /></IconButton>
+      </Box>
+      {matchup && (
+        <Box display="flex" alignItems="center" justifyContent="center" gap={2} mt={1}>
+          <Typography variant="h6" fontWeight={700} sx={{ flex: 1, textAlign: 'right' }} noWrap>
+            {matchup.homeTeamName ?? 'Ghost'}
+          </Typography>
+          <Typography variant="h5" fontWeight={800} color="text.secondary" sx={{ minWidth: 80, textAlign: 'center' }}>
+            {matchup.homeScore != null ? Number(matchup.homeScore).toFixed(1) : '—'} – {matchup.awayScore != null ? Number(matchup.awayScore).toFixed(1) : '—'}
+          </Typography>
+          <Typography variant="h6" fontWeight={700} sx={{ flex: 1 }} noWrap>
+            {matchup.awayTeamName ?? 'Ghost'}
+          </Typography>
+        </Box>
+      )}
+    </DialogTitle>
+    <DialogContent>
+      {matchup && (
+        <MatchupDetail
+          matchup={matchup}
+          userTeamId={userTeamId}
+          seasonYear={seasonYear}
+          seasonId={seasonId}
+        />
+      )}
+    </DialogContent>
+  </Dialog>
+);
 
 export default MatchupDetailModal;

--- a/src/components/RodadaTab.tsx
+++ b/src/components/RodadaTab.tsx
@@ -1,0 +1,304 @@
+import React, { useState, useMemo } from 'react';
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  Collapse,
+  IconButton,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  Typography,
+} from '@mui/material';
+import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
+import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+import { useScheduleBySeason, usePlayoffMatchups, FantasyMatchupDto } from '../api/fantasyMatchupQueries';
+import { MatchupDetail } from './MatchupDetailModal';
+
+interface Props {
+  seasonId: string | undefined;
+  userTeamId?: number;
+  seasonYear?: number;
+  currentRound?: number | null;
+  playoffStartRound?: number | null;
+  numberOfRounds?: number | null;
+}
+
+function detectCurrentRound(
+  regularRounds: number[],
+  playoffRounds: number[],
+  regularSchedule: { roundNumber: number; matchups: FantasyMatchupDto[] }[],
+): number {
+  const activeRegular = regularSchedule.find((r) =>
+    r.matchups.some((m) => m.status !== 'completed' && m.status !== 'bye'),
+  );
+  if (activeRegular) return activeRegular.roundNumber;
+  if (playoffRounds.length > 0) return playoffRounds[0];
+  return regularRounds[regularRounds.length - 1];
+}
+
+// ─── Single matchup row: collapsed = score card, expanded = full detail ──────
+
+const MatchupRow: React.FC<{
+  matchup: FantasyMatchupDto;
+  isExpanded: boolean;
+  isHighlighted: boolean;
+  onToggle: () => void;
+  userTeamId?: number;
+  seasonYear?: number;
+  seasonId?: string;
+}> = ({ matchup, isExpanded, isHighlighted, onToggle, userTeamId, seasonYear, seasonId }) => {
+  const STATUS_COLORS: Record<string, string> = {
+    scheduled: 'default',
+    live: 'warning',
+    completed: 'success',
+  };
+  const STATUS_LABELS: Record<string, string> = {
+    scheduled: 'Agendado',
+    live: 'Ao Vivo',
+    completed: 'Encerrado',
+  };
+
+  const homeScore = matchup.homeScore != null ? Number(matchup.homeScore).toFixed(1) : '—';
+  const awayScore = matchup.awayScore != null ? Number(matchup.awayScore).toFixed(1) : '—';
+
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        overflow: 'hidden',
+        borderColor: isHighlighted ? 'primary.main' : undefined,
+        borderWidth: isHighlighted ? 2 : 1,
+      }}
+    >
+      {/* Header row — always visible, click to toggle */}
+      <Box
+        onClick={matchup.status !== 'bye' ? onToggle : undefined}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          px: 2,
+          py: 1.25,
+          cursor: matchup.status !== 'bye' ? 'pointer' : 'default',
+          bgcolor: isExpanded ? 'action.selected' : 'transparent',
+          '&:hover': matchup.status !== 'bye' ? { bgcolor: 'action.hover' } : {},
+          userSelect: 'none',
+        }}
+      >
+        <Typography
+          variant="body2"
+          fontWeight={isHighlighted ? 700 : 400}
+          sx={{ flex: 1, textAlign: 'right' }}
+          noWrap
+        >
+          {matchup.homeTeamName ?? 'Ghost'}
+        </Typography>
+        <Typography
+          variant="body2"
+          fontWeight={700}
+          color="text.secondary"
+          sx={{ mx: 2, minWidth: 90, textAlign: 'center', fontVariantNumeric: 'tabular-nums' }}
+        >
+          {homeScore} – {awayScore}
+        </Typography>
+        <Typography
+          variant="body2"
+          fontWeight={isHighlighted ? 700 : 400}
+          sx={{ flex: 1 }}
+          noWrap
+        >
+          {matchup.awayTeamName ?? 'Ghost'}
+        </Typography>
+        <Chip
+          label={STATUS_LABELS[matchup.status] ?? matchup.status}
+          size="small"
+          color={(STATUS_COLORS[matchup.status] ?? 'default') as any}
+          sx={{ ml: 1.5, flexShrink: 0 }}
+        />
+      </Box>
+
+      {/* Expandable detail */}
+      {matchup.status !== 'bye' && (
+        <Collapse in={isExpanded} unmountOnExit>
+          <Box px={2} pb={2} pt={1}>
+            <MatchupDetail
+              matchup={matchup}
+              userTeamId={userTeamId}
+              seasonYear={seasonYear}
+              seasonId={seasonId}
+            />
+          </Box>
+        </Collapse>
+      )}
+    </Paper>
+  );
+};
+
+// ─── Main tab ─────────────────────────────────────────────────────────────────
+
+const RodadaTab: React.FC<Props> = ({
+  seasonId,
+  userTeamId,
+  seasonYear,
+  currentRound,
+  playoffStartRound,
+  numberOfRounds,
+}) => {
+  const { data: schedule, isLoading: scheduleLoading } = useScheduleBySeason(seasonId);
+  const { data: playoffMatchups, isLoading: playoffLoading } = usePlayoffMatchups(seasonId);
+  const [selectedRound, setSelectedRound] = useState<number | null>(null);
+  const [expandedMatchupId, setExpandedMatchupId] = useState<string | null>(null);
+
+  const isLoading = scheduleLoading || playoffLoading;
+
+  const regularRounds = useMemo(() => (schedule ?? []).map((r) => r.roundNumber), [schedule]);
+
+  const playoffRounds = useMemo(() => {
+    if (!playoffStartRound || !numberOfRounds) return [];
+    return Array.from({ length: numberOfRounds - playoffStartRound + 1 }, (_, i) => playoffStartRound + i);
+  }, [playoffStartRound, numberOfRounds]);
+
+  const allRounds = useMemo(
+    () => [...regularRounds, ...playoffRounds.filter((r) => !regularRounds.includes(r))],
+    [regularRounds, playoffRounds],
+  );
+
+  const currentRoundNumber = useMemo(() => {
+    if (currentRound != null) return currentRound;
+    if (regularRounds.length > 0)
+      return detectCurrentRound(regularRounds, playoffRounds, schedule ?? []);
+    return null;
+  }, [currentRound, regularRounds, playoffRounds, schedule]);
+
+  if (!seasonId) {
+    return (
+      <Typography color="text.secondary" textAlign="center" py={6}>
+        Temporada não encontrada.
+      </Typography>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <Box display="flex" justifyContent="center" py={6}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (!schedule || schedule.length === 0) {
+    return (
+      <Typography color="text.secondary" textAlign="center" py={6}>
+        A tabela ainda não foi gerada. Ela será gerada automaticamente ao fim do draft.
+      </Typography>
+    );
+  }
+
+  const activeRound = selectedRound ?? currentRoundNumber ?? allRounds[0];
+  const activeIndex = allRounds.indexOf(activeRound);
+  const isPlayoffRound = playoffStartRound != null && activeRound >= playoffStartRound;
+
+  function isMyMatchup(m: { homeTeamId: number | null; awayTeamId: number | null }) {
+    return userTeamId != null && (m.homeTeamId === userTeamId || m.awayTeamId === userTeamId);
+  }
+
+  const activeRoundData = schedule.find((r) => r.roundNumber === activeRound);
+  const roundPlayoffMatchups = (playoffMatchups ?? []).filter((m) => m.roundNumber === activeRound);
+
+  const allMatchups: FantasyMatchupDto[] = isPlayoffRound
+    ? roundPlayoffMatchups
+    : (activeRoundData?.matchups ?? []);
+
+  // Stable order: user's matchup first, then others in original order
+  const myMatchup = allMatchups.find(isMyMatchup) ?? null;
+  const orderedMatchups = myMatchup
+    ? [myMatchup, ...allMatchups.filter((m) => m.id !== myMatchup.id)]
+    : allMatchups;
+
+  // Default expansion: user's matchup open on mount / round change
+  const defaultExpandedId = myMatchup?.id ?? orderedMatchups[0]?.id ?? null;
+  const expandedId = expandedMatchupId !== undefined ? expandedMatchupId : defaultExpandedId;
+
+  const handleRoundChange = (round: number) => {
+    setSelectedRound(round);
+    setExpandedMatchupId(null); // reset to default (user's matchup)
+  };
+
+  return (
+    <Box>
+      {/* Round selector */}
+      <Stack direction="row" alignItems="center" spacing={1} mb={3}>
+        <IconButton
+          size="small"
+          disabled={activeIndex <= 0}
+          onClick={() => handleRoundChange(allRounds[activeIndex - 1])}
+        >
+          <ArrowBackIosNewIcon fontSize="small" />
+        </IconButton>
+
+        <Select
+          value={activeRound}
+          onChange={(e) => handleRoundChange(Number(e.target.value))}
+          size="small"
+          sx={{ minWidth: 180 }}
+          renderValue={(val) => {
+            const isPlayoff = playoffStartRound != null && val >= playoffStartRound;
+            return (
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Typography fontWeight={600}>Rodada {val}</Typography>
+                {isPlayoff && <Chip label="Mata-mata" size="small" color="warning" sx={{ height: 18, fontSize: 11 }} />}
+                {val === currentRoundNumber && <Chip label="Atual" size="small" color="primary" sx={{ height: 18, fontSize: 11 }} />}
+              </Box>
+            );
+          }}
+        >
+          {allRounds.map((r) => {
+            const isPlayoff = playoffStartRound != null && r >= playoffStartRound;
+            return (
+              <MenuItem key={r} value={r}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  Rodada {r}
+                  {isPlayoff && <Chip label="Mata-mata" size="small" color="warning" sx={{ height: 18, fontSize: 11 }} />}
+                  {r === currentRoundNumber && <Chip label="Atual" size="small" color="primary" sx={{ height: 18, fontSize: 11 }} />}
+                </Box>
+              </MenuItem>
+            );
+          })}
+        </Select>
+
+        <IconButton
+          size="small"
+          disabled={activeIndex >= allRounds.length - 1}
+          onClick={() => handleRoundChange(allRounds[activeIndex + 1])}
+        >
+          <ArrowForwardIosIcon fontSize="small" />
+        </IconButton>
+      </Stack>
+
+      {/* Matchup list — stable order, expand/collapse in place */}
+      {orderedMatchups.length === 0 ? (
+        <Typography color="text.secondary" textAlign="center" py={4}>
+          Nenhum jogo nesta rodada.
+        </Typography>
+      ) : (
+        <Stack spacing={1}>
+          {orderedMatchups.map((m) => (
+            <MatchupRow
+              key={m.id}
+              matchup={m}
+              isExpanded={expandedId === m.id}
+              isHighlighted={isMyMatchup(m)}
+              onToggle={() => setExpandedMatchupId(expandedId === m.id ? null : m.id)}
+              userTeamId={userTeamId}
+              seasonYear={seasonYear}
+              seasonId={seasonId}
+            />
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+};
+
+export default RodadaTab;

--- a/src/components/RosterSettingsForm.tsx
+++ b/src/components/RosterSettingsForm.tsx
@@ -1,14 +1,20 @@
 import React, { useState } from 'react';
 import {
+  Alert,
   Box,
-  Typography,
-  TextField,
   Button,
+  Snackbar,
+  TextField,
   ToggleButton,
   ToggleButtonGroup,
+  Typography,
 } from '@mui/material';
 import { RosterSettings, useUpdateRosterSettings } from '../api/useUpdateRosterSettings';
-import { Snackbar, Alert } from '@mui/material';
+
+const ROSTER_LOCKED_STATUSES = [
+  'DRAFT_SCHEDULED', 'DRAFT_LIVE', 'DRAFT_DONE',
+  'SCHEDULED', 'ACTIVE', 'SEASON_ENDED', 'ARCHIVED',
+];
 
 interface Props {
   values: RosterSettings;
@@ -16,10 +22,12 @@ interface Props {
   id: number;
   refetchRosterSettings: () => void;
   refetchDraftSettings: () => void;
+  seasonStatus?: string;
 }
 
-const RosterSettingsForm: React.FC<Props> = ({ values, onChange, id , refetchRosterSettings, refetchDraftSettings }) => {
-const [openSnackbar, setOpenSnackbar] = useState(false);
+const RosterSettingsForm: React.FC<Props> = ({ values, onChange, id, refetchRosterSettings, refetchDraftSettings, seasonStatus }) => {
+  const [openSnackbar, setOpenSnackbar] = useState(false);
+  const isLocked = !!seasonStatus && ROSTER_LOCKED_STATUSES.includes(seasonStatus);
   const updateRoster = useUpdateRosterSettings({
     onSuccess: () => {
       setOpenSnackbar(true);
@@ -36,6 +44,11 @@ const [openSnackbar, setOpenSnackbar] = useState(false);
 
   return (
     <>
+      {isLocked && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          Configurações de elenco bloqueadas — o draft já foi agendado.
+        </Alert>
+      )}
       {/* Starter Settings */}
       <Typography fontWeight={600} sx={{ mb: 2, fontSize: '1.2rem' }}>Jogadores Titulares</Typography>
       <Box>
@@ -44,6 +57,7 @@ const [openSnackbar, setOpenSnackbar] = useState(false);
           fullWidth
           type="number"
           inputProps={{ min: 4, max: 8 }}
+          disabled={isLocked}
           value={values.starterSkillSlots}
           onChange={(e) => {
             const value = Number(e.target.value);
@@ -59,6 +73,7 @@ const [openSnackbar, setOpenSnackbar] = useState(false);
         <TextField
           fullWidth
           type="number"
+          disabled={isLocked}
           value={values.minStarterMidfielders}
           onChange={(e) => {
             const value = Number(e.target.value);
@@ -78,6 +93,7 @@ const [openSnackbar, setOpenSnackbar] = useState(false);
         <TextField
           fullWidth
           type="number"
+          disabled={isLocked}
           value={values.minStarterForwards}
           onChange={(e) => {
             const value = Number(e.target.value);
@@ -96,6 +112,7 @@ const [openSnackbar, setOpenSnackbar] = useState(false);
         <TextField
           fullWidth
           type="number"
+          disabled={isLocked}
           value={values.starterDefenseSlots}
           onChange={(e) => {
             const value = Number(e.target.value);
@@ -113,6 +130,7 @@ const [openSnackbar, setOpenSnackbar] = useState(false);
         <TextField
           fullWidth
           type="number"
+          disabled={isLocked}
           value={values.benchSkillSlots}
           onChange={(e) => onChange('benchSkillSlots', Number(e.target.value))}
         />
@@ -123,6 +141,7 @@ const [openSnackbar, setOpenSnackbar] = useState(false);
         <TextField
           fullWidth
           type="number"
+          disabled={isLocked}
           value={values.minBenchMidfielders}
           onChange={(e) => {
             const value = Number(e.target.value);
@@ -142,6 +161,7 @@ const [openSnackbar, setOpenSnackbar] = useState(false);
         <TextField
           fullWidth
           type="number"
+          disabled={isLocked}
           value={values.minBenchForwards}
           onChange={(e) => {
             const value = Number(e.target.value);
@@ -160,6 +180,7 @@ const [openSnackbar, setOpenSnackbar] = useState(false);
         <TextField
           fullWidth
           type="number"
+          disabled={isLocked}
           value={values.benchDefenseSlots}
           onChange={(e) => {
             const value = Number(e.target.value);
@@ -174,7 +195,8 @@ const [openSnackbar, setOpenSnackbar] = useState(false);
         <ToggleButtonGroup
           exclusive
           value={values.defenseType ?? 'CLOSED'}
-          onChange={(_, val) => { if (val) onChange('defenseType', val); }}
+          onChange={(_, val) => { if (val && !isLocked) onChange('defenseType', val); }}
+          disabled={isLocked}
           size="small"
         >
           <ToggleButton value="CLOSED">Defesa Fechada</ToggleButton>
@@ -198,7 +220,7 @@ const [openSnackbar, setOpenSnackbar] = useState(false);
       <Button
         variant="contained"
         onClick={() => updateRoster.mutate({ id, updates: values })}
-        disabled={updateRoster.isPending || isStarterTotalExceeded || isBenchTotalExceeded}
+        disabled={updateRoster.isPending || isStarterTotalExceeded || isBenchTotalExceeded || isLocked}
       >
         Salvar
       </Button>

--- a/src/components/ScheduleTab.tsx
+++ b/src/components/ScheduleTab.tsx
@@ -1,20 +1,6 @@
-import React, { useState, useMemo } from 'react';
-import {
-  Box,
-  CircularProgress,
-  Divider,
-  IconButton,
-  MenuItem,
-  Select,
-  Stack,
-  Typography,
-  Chip,
-} from '@mui/material';
-import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
-import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
-import { useScheduleBySeason, usePlayoffMatchups, FantasyMatchupDto } from '../api/fantasyMatchupQueries';
-import MatchupCard from './MatchupCard';
-import MatchupDetailModal from './MatchupDetailModal';
+import React from 'react';
+import { Box, CircularProgress, Divider, Typography } from '@mui/material';
+import { usePlayoffMatchups } from '../api/fantasyMatchupQueries';
 import PlayoffBracket from './PlayoffBracket';
 import StandingsTable from './StandingsTable';
 
@@ -27,87 +13,8 @@ interface Props {
   numberOfRounds?: number | null;
 }
 
-function detectCurrentRoundFromSchedule(
-  regularRounds: number[],
-  playoffRounds: number[],
-  regularSchedule: { roundNumber: number; matchups: FantasyMatchupDto[] }[],
-): number {
-  // First look for an unfinished regular season round
-  const activeRegular = regularSchedule.find((r) =>
-    r.matchups.some((m) => m.status !== 'completed' && m.status !== 'bye'),
-  );
-  if (activeRegular) return activeRegular.roundNumber;
-  // Then fall through to first playoff round if any exist
-  if (playoffRounds.length > 0) return playoffRounds[0];
-  // Otherwise last regular round
-  return regularRounds[regularRounds.length - 1];
-}
-
-const ScheduleTab: React.FC<Props> = ({
-  seasonId,
-  userTeamId,
-  seasonYear,
-  currentRound,
-  playoffStartRound,
-  numberOfRounds,
-}) => {
-  const { data: schedule, isLoading: scheduleLoading } = useScheduleBySeason(seasonId);
-  const { data: playoffMatchups, isLoading: playoffLoading } = usePlayoffMatchups(seasonId);
-  const [selectedRound, setSelectedRound] = useState<number | null>(null);
-  const [selectedMatchup, setSelectedMatchup] = useState<FantasyMatchupDto | null>(null);
-
-  const isLoading = scheduleLoading || playoffLoading;
-
-  // All regular season round numbers from the schedule
-  const regularRounds = useMemo(
-    () => (schedule ?? []).map((r) => r.roundNumber),
-    [schedule],
-  );
-
-  // Unique playoff round numbers from fetched playoff matchups
-  const playoffRounds = useMemo(() => {
-    if (!playoffStartRound || !numberOfRounds) return [];
-    // Build the full range even if matchups aren't generated yet
-    return Array.from(
-      { length: numberOfRounds - playoffStartRound + 1 },
-      (_, i) => playoffStartRound + i,
-    );
-  }, [playoffStartRound, numberOfRounds]);
-
-  // Full ordered round list: regular + playoff
-  const allRounds = useMemo(
-    () => [...regularRounds, ...playoffRounds.filter((r) => !regularRounds.includes(r))],
-    [regularRounds, playoffRounds],
-  );
-
-  const currentRoundNumber = useMemo(() => {
-    if (currentRound != null) return currentRound;
-    if (regularRounds.length > 0)
-      return detectCurrentRoundFromSchedule(regularRounds, playoffRounds, schedule ?? []);
-    return null;
-  }, [currentRound, regularRounds, playoffRounds, schedule]);
-
-  // For two-leg ties, determine if this round is Jogo 1 or Jogo 2 within each pair.
-  // Within a twoLegPairId group, the lower roundNumber = leg 1, higher = leg 2.
-  const legNumberByMatchupId = useMemo(() => {
-    const map = new Map<string, number>();
-    if (!playoffMatchups) return map;
-
-    const byPair = new Map<string, typeof playoffMatchups>();
-    for (const matchup of playoffMatchups) {
-      if (!matchup.twoLegPairId) continue;
-      const group = byPair.get(matchup.twoLegPairId) ?? [];
-      group.push(matchup);
-      byPair.set(matchup.twoLegPairId, group);
-    }
-
-    byPair.forEach((legs) => {
-      const sorted = [...legs].sort((legA, legB) => legA.roundNumber - legB.roundNumber);
-      sorted.forEach((leg, index) => map.set(leg.id, index + 1));
-    });
-
-    return map;
-  }, [playoffMatchups]);
+const ScheduleTab: React.FC<Props> = ({ seasonId, userTeamId, seasonYear }) => {
+  const { data: playoffMatchups, isLoading } = usePlayoffMatchups(seasonId);
 
   if (!seasonId) {
     return (
@@ -125,155 +32,10 @@ const ScheduleTab: React.FC<Props> = ({
     );
   }
 
-  if (!schedule || schedule.length === 0) {
-    return (
-      <Typography color="text.secondary" textAlign="center" py={6}>
-        A tabela ainda não foi gerada. Ela será gerada automaticamente ao fim do draft.
-      </Typography>
-    );
-  }
-
-  const activeRound = selectedRound ?? currentRoundNumber ?? allRounds[0];
-  const activeIndex = allRounds.indexOf(activeRound);
-  const isPlayoffRound = playoffStartRound != null && activeRound >= playoffStartRound;
-
-  // Regular season matchups for the selected round
-  const activeRoundData = schedule.find((r) => r.roundNumber === activeRound);
-  const regularMatchups = activeRoundData
-    ? [...activeRoundData.matchups].sort(
-        (a, b) => (isMyMatchup(b) ? 1 : 0) - (isMyMatchup(a) ? 1 : 0),
-      )
-    : [];
-
-  // Playoff matchups for the selected round
-  const roundPlayoffMatchups = (playoffMatchups ?? []).filter(
-    (matchup) => matchup.roundNumber === activeRound,
-  );
-
-  function isMyMatchup(m: { homeTeamId: number | null; awayTeamId: number | null }) {
-    return userTeamId != null && (m.homeTeamId === userTeamId || m.awayTeamId === userTeamId);
-  }
-
-  const getStageLabel = (stage: number | null): string | null => {
-    if (stage === 1) return 'Final';
-    if (stage === 2) return 'Semifinal';
-    if (stage === 3) return 'Quartas de Final';
-    return null;
-  };
-
-  const firstStage = roundPlayoffMatchups[0]?.playoffStage ?? null;
-  const stageLabel = getStageLabel(firstStage);
-
   const hasPlayoffMatchups = playoffMatchups && playoffMatchups.length > 0;
 
   return (
     <Box>
-      {/* Round selector */}
-      <Stack direction="row" alignItems="center" spacing={1}>
-        <IconButton
-          size="small"
-          disabled={activeIndex <= 0}
-          onClick={() => setSelectedRound(allRounds[activeIndex - 1])}
-        >
-          <ArrowBackIosNewIcon fontSize="small" />
-        </IconButton>
-
-        <Select
-          value={activeRound}
-          onChange={(e) => setSelectedRound(Number(e.target.value))}
-          size="small"
-          sx={{ minWidth: 180 }}
-          renderValue={(val) => {
-            const isPlayoff = playoffStartRound != null && val >= playoffStartRound;
-            return (
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                <Typography fontWeight={600}>Rodada {val}</Typography>
-                {isPlayoff && (
-                  <Chip label="Mata-mata" size="small" color="warning" sx={{ height: 18, fontSize: 11 }} />
-                )}
-                {val === currentRoundNumber && (
-                  <Chip label="Atual" size="small" color="primary" sx={{ height: 18, fontSize: 11 }} />
-                )}
-              </Box>
-            );
-          }}
-        >
-          {allRounds.map((r) => {
-            const isPlayoff = playoffStartRound != null && r >= playoffStartRound;
-            return (
-              <MenuItem key={r} value={r}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  Rodada {r}
-                  {isPlayoff && (
-                    <Chip label="Mata-mata" size="small" color="warning" sx={{ height: 18, fontSize: 11 }} />
-                  )}
-                  {r === currentRoundNumber && (
-                    <Chip label="Atual" size="small" color="primary" sx={{ height: 18, fontSize: 11 }} />
-                  )}
-                </Box>
-              </MenuItem>
-            );
-          })}
-        </Select>
-
-        <IconButton
-          size="small"
-          disabled={activeIndex >= allRounds.length - 1}
-          onClick={() => setSelectedRound(allRounds[activeIndex + 1])}
-        >
-          <ArrowForwardIosIcon fontSize="small" />
-        </IconButton>
-      </Stack>
-
-      {/* Matchups area */}
-      <Box mt={3}>
-        {isPlayoffRound ? (
-          roundPlayoffMatchups.length > 0 ? (
-            <Stack spacing={1.5}>
-              {stageLabel && (
-                <Typography variant="subtitle2" fontWeight={700} color="warning.main" mb={0.5}>
-                  {stageLabel}
-                </Typography>
-              )}
-              {roundPlayoffMatchups.map((playoffMatchup) => {
-                const legNumber = legNumberByMatchupId.get(playoffMatchup.id) ?? null;
-                return (
-                  <Box key={playoffMatchup.id}>
-                    {legNumber !== null && (
-                      <Typography variant="caption" color="text.secondary" mb={0.5} display="block">
-                        Jogo {legNumber}
-                      </Typography>
-                    )}
-                    <MatchupCard
-                      matchup={playoffMatchup}
-                      highlighted={isMyMatchup(playoffMatchup)}
-                      onClick={playoffMatchup.status !== 'bye' ? () => setSelectedMatchup(playoffMatchup) : undefined}
-                    />
-                  </Box>
-                );
-              })}
-            </Stack>
-          ) : (
-            <Typography color="text.secondary" textAlign="center" py={4}>
-              Mata-mata a ser definido
-            </Typography>
-          )
-        ) : (
-          <Stack spacing={1.5}>
-            {regularMatchups.map((matchup) => (
-              <MatchupCard
-                key={matchup.id}
-                matchup={matchup}
-                highlighted={isMyMatchup(matchup)}
-                onClick={matchup.status !== 'bye' ? () => setSelectedMatchup(matchup) : undefined}
-              />
-            ))}
-          </Stack>
-        )}
-      </Box>
-
-      <Divider sx={{ my: 4 }} />
-
       <Typography variant="h6" fontWeight={700} mb={2}>
         Classificação
       </Typography>
@@ -288,14 +50,6 @@ const ScheduleTab: React.FC<Props> = ({
           <PlayoffBracket seasonId={seasonId} seasonYear={seasonYear} />
         </>
       )}
-
-      <MatchupDetailModal
-        matchup={selectedMatchup}
-        onClose={() => setSelectedMatchup(null)}
-        userTeamId={userTeamId}
-        seasonYear={seasonYear}
-        seasonId={seasonId}
-      />
     </Box>
   );
 };

--- a/src/pages/FantasyLeague.tsx
+++ b/src/pages/FantasyLeague.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useGetFantasyLeague } from '../api/fantasyLeagueQueries';
 import LeagueSidebar from '../components/FantasyLeaguesSidebar';
@@ -21,6 +21,8 @@ import { useFantasyLeagueSeasons } from '../api/useFantasyLeagueSeasons';
 import { useCurrentSeason } from '../api/currentSeasonQueries';
 import { useWaiverClaims, useWaiverBudgets, useWaiverWindowStatus, useMarketHistory } from '../api/waiverQueries';
 import { useTrades } from '../api/tradeQueries';
+import ScoringConfigForm from '../components/ScoringConfigForm';
+import RodadaTab from '../components/RodadaTab';
 
 const FantasyLeaguePage = ({ currentUserId }: { currentUserId: number }) => {
   const { fantasyLeagueId } = useParams<{ fantasyLeagueId: string }>();
@@ -32,6 +34,7 @@ const FantasyLeaguePage = ({ currentUserId }: { currentUserId: number }) => {
     severity: 'success' as 'success' | 'error',
   });
   const [selectedTab, setSelectedTab] = useState('draft');
+  const [defaultTabSet, setDefaultTabSet] = useState(false);
   const [viewInvitesModalOpen, setViewInvitesModalOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
   const theme = useTheme();
@@ -40,6 +43,17 @@ const FantasyLeaguePage = ({ currentUserId }: { currentUserId: number }) => {
   const { mutate: inviteUserToFantasyLeague, isPending: isInvitingUser, isError: isInvitingUserError, error: invitingUserError } = useInviteUserToFantasyLeague(Number(fantasyLeagueId));
   const { data: userTeam, isLoading: isLoadingUserTeam, isError: isLoadingUserTeamError, error: errorUserTeam } = useFindUserFantasyLeagueTeam(currentUserId, Number(fantasyLeagueId));
   const { data: fantasyLeagueSeason } = useFantasyLeagueSeasons(Number(fantasyLeagueId));
+
+  const POST_DRAFT_STATUSES = ['DRAFT_DONE', 'SCHEDULED', 'ACTIVE', 'SEASON_ENDED', 'ARCHIVED'];
+  useEffect(() => {
+    if (!defaultTabSet && fantasyLeagueSeason?.status) {
+      if (POST_DRAFT_STATUSES.includes(fantasyLeagueSeason.status)) {
+        setSelectedTab('rodada');
+      }
+      setDefaultTabSet(true);
+    }
+  }, [fantasyLeagueSeason?.status, defaultTabSet]);
+
   const { data: currentSeasonData } = useCurrentSeason();
   const seasonYear = fantasyLeagueSeason?.seasonYear ?? currentSeasonData?.year ?? new Date().getFullYear();
 
@@ -125,6 +139,7 @@ const FantasyLeaguePage = ({ currentUserId }: { currentUserId: number }) => {
           {selectedTab === 'draft' && <DraftTab fantasyLeague={fantasyLeague} currentUserId={currentUserId} />}
           {selectedTab === 'team' && <TeamTab seasonYear={seasonYear} seasonId={fantasyLeagueSeason?.id} userTeam={userTeam} fantasyLeague={fantasyLeague} />}
           {selectedTab === 'schedule' && <ScheduleTab seasonId={fantasyLeagueSeason?.id} userTeamId={userTeam?.id} seasonYear={seasonYear} currentRound={fantasyLeagueSeason?.currentRound ?? null} playoffStartRound={fantasyLeagueSeason?.playoffStartRound ?? null} numberOfRounds={fantasyLeagueSeason?.numberOfRounds ?? null} />}
+          {selectedTab === 'rodada' && <RodadaTab seasonId={fantasyLeagueSeason?.id} userTeamId={userTeam?.id} seasonYear={seasonYear} currentRound={fantasyLeagueSeason?.currentRound ?? null} playoffStartRound={fantasyLeagueSeason?.playoffStartRound ?? null} numberOfRounds={fantasyLeagueSeason?.numberOfRounds ?? null} />}
           {selectedTab === 'league' && <FantasyLeagueInfo currentUserId={currentUserId} fantasyLeague={fantasyLeague} />}
           {selectedTab === 'players' && (
             <Box display="flex" flexDirection="column" gap={2}>
@@ -158,7 +173,13 @@ const FantasyLeaguePage = ({ currentUserId }: { currentUserId: number }) => {
               tradeDeadlineRound={fantasyLeagueSeason?.tradeDeadlineRound}
             />
           )}
-          {selectedTab === 'scores' && <div>Scores table</div>}
+          {selectedTab === 'scores' && (
+            <ScoringConfigForm
+              seasonId={fantasyLeagueSeason?.id}
+              seasonStatus={fantasyLeagueSeason?.status}
+              isOwner={false}
+            />
+          )}
         </Box>
       </Box>
 


### PR DESCRIPTION
Settings locking:
- Season, draft, and roster settings forms show warning banner and disable all inputs after draft is scheduled/done (mirroring the existing scoring config lock pattern)

Pontuações tab:
- Filled the empty Scores tab with a read-only ScoringConfigForm showing all stat point values (Ataque + Defesa) for all league members

Rodada tab (new):
- New tab between Tabela and Liga showing per-round fantasy matchups
- All matchups listed in stable order (user's game first) as expand/collapse rows — clicking a row expands inline MatchupDetail with rosters, scores, and player stats; clicking again collapses
- No reordering or flash on selection
- Extracted MatchupDetail from MatchupDetailModal for reuse inline
- Tabela tab stripped to standings + playoff bracket only
- After draft is done, Rodada becomes the default tab on page load
- Score row and team names removed from inline detail (already in header)