### PR TITLE
feat(rounds): rename currentRound and use currentRealRound for API calls

### DIFF
--- a/src/api/useFantasyLeagueSeasons.ts
+++ b/src/api/useFantasyLeagueSeasons.ts
@@ -15,7 +15,8 @@ export interface FantasyLeagueSeason {
   activatedAt: string;
   status: string;
   seasonYear: number;
-  currentRound: number | null;
+  currentFantasyRound: number | null;
+  currentRealRound: number | null;
   waiverSystem: 'AUCTION' | 'PRIORITY';
   initialWaiverBudget: number;
   fantasyLeague?: { league?: { externalId?: number } };

--- a/src/components/PlayersList.tsx
+++ b/src/components/PlayersList.tsx
@@ -94,12 +94,12 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   const { data: season } = useFantasyLeagueSeasons(fantasyLeague.id);
-  const activeRound = currentRound ?? season?.currentRound ?? null;
+  const activeRealRound = currentRound ?? season?.currentRealRound ?? null;
   const { data: realMatches } = useRealMatchesByRound(
-    activeRound ? seasonYear : undefined,
-    activeRound ?? undefined,
+    activeRealRound ? seasonYear : undefined,
+    activeRealRound ?? undefined,
   );
-  const { data: lockedTeamsData } = useLockedTeams(fantasyLeague.league.externalId, seasonYear, activeRound);
+  const { data: lockedTeamsData } = useLockedTeams(fantasyLeague.league.externalId, seasonYear, activeRealRound);
   const lockedTeamIds = new Set<number>(lockedTeamsData?.lockedTeamIds ?? []);
   const draftCompleted = season ? POST_DRAFT_STATUSES.includes(season.status as LeagueStatus) : false;
 

--- a/src/components/SeasonStatusCard.tsx
+++ b/src/components/SeasonStatusCard.tsx
@@ -226,6 +226,14 @@ const getErrorMessage = (err: unknown) => {
                 {season.playoffTeams ? ` • ${season.playoffTeams}  se classificam para o mata mata` : ''}
               </Typography>
 
+              {phase === 'temporada' && season.currentFantasyRound != null && (
+                <Typography variant="body2" color="text.secondary">
+                  {season.currentRealRound != null && season.currentRealRound !== season.currentFantasyRound
+                    ? `Rodada ${season.currentFantasyRound} da Liga • Rodada ${season.currentRealRound} do Campeonato`
+                    : `Rodada ${season.currentFantasyRound}`}
+                </Typography>
+              )}
+
               {phase === 'playoffs-encerrados' && (
                 <Typography variant="body2" fontWeight={700} color="warning.main">
                   🏆 Campeão{championTeamName ? `: ${championTeamName}` : ''}

--- a/src/components/TeamTabComponent.tsx
+++ b/src/components/TeamTabComponent.tsx
@@ -14,7 +14,7 @@ import { UserTeam } from '../api/userTeamsQueries';
 import Loading from './Loading';
 import { useRealMatchesByRound } from '../api/matchesQueries';
 import { getOpponentForTeam } from '../utils/matchUtils';
-import { useLockedTeams } from '../api/fantasyRoundGameQueries';
+import { useLockedTeams } from '../api/fantasyRoundGameQueries';  
 import { useFantasyLeagueSeasons } from '../api/useFantasyLeagueSeasons';
 
 interface Props {
@@ -25,7 +25,6 @@ interface Props {
   }
 
   export const TeamTab: React.FC<Props> = ({ userTeam, fantasyLeague, seasonYear, seasonId }) => {
-    console.log('[TeamTab] seasonYear:', seasonYear);
     const [selectedSlot, setSelectedSlot] = useState<any | null>(null);
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [moveOpen, setMoveOpen] = useState(false);
@@ -37,9 +36,9 @@ interface Props {
 
     const { data: leagueTeams } = useFantasyLeagueTeams(fantasyLeague.id);
     const { data: season } = useFantasyLeagueSeasons(fantasyLeague.id);
-    const currentRound = season?.currentRound ?? undefined;
-    const { data: realMatches } = useRealMatchesByRound(seasonYear, currentRound);
-    const { data: lockedTeamsData } = useLockedTeams(fantasyLeague.league.externalId, seasonYear, currentRound);
+    const currentRealRound = season?.currentRealRound ?? undefined;
+    const { data: realMatches } = useRealMatchesByRound(seasonYear, currentRealRound);
+    const { data: lockedTeamsData } = useLockedTeams(fantasyLeague.league.externalId, seasonYear, currentRealRound);
     const lockedTeamIds = new Set<number>(lockedTeamsData?.lockedTeamIds ?? []);
     const isViewingOwnTeam = selectedTeamId === userTeam.id;
     const viewedTeam = leagueTeams?.find((t: FantasyLeagueTeamsResponse) => t.id === selectedTeamId);

--- a/src/components/TradesTab.tsx
+++ b/src/components/TradesTab.tsx
@@ -30,7 +30,7 @@ interface Props {
   userTeam: { id: number; name: string } | null | undefined;
   fantasyLeague: FantasyLeague;
   currentUserId: number;
-  currentRound?: number | null;
+  currentFantasyRound?: number | null;
   tradeDeadlineRound?: number | null;
 }
 
@@ -227,7 +227,7 @@ const TradesTab: React.FC<Props> = ({
   userTeam,
   fantasyLeague,
   currentUserId,
-  currentRound,
+  currentFantasyRound,
   tradeDeadlineRound,
 }) => {
   const { data: trades = [], isLoading } = useTrades(seasonId);
@@ -237,8 +237,8 @@ const TradesTab: React.FC<Props> = ({
   const isOwner = fantasyLeague.owner?.id === currentUserId;
   const deadlinePassed =
     tradeDeadlineRound != null &&
-    currentRound != null &&
-    currentRound > tradeDeadlineRound;
+    currentFantasyRound != null &&
+    currentFantasyRound > tradeDeadlineRound;
 
   if (!seasonId) {
     return <Typography color="text.secondary">Temporada ainda não ativada.</Typography>;

--- a/src/pages/FantasyLeague.tsx
+++ b/src/pages/FantasyLeague.tsx
@@ -138,8 +138,8 @@ const FantasyLeaguePage = ({ currentUserId }: { currentUserId: number }) => {
         <Box mt={4}>
           {selectedTab === 'draft' && <DraftTab fantasyLeague={fantasyLeague} currentUserId={currentUserId} />}
           {selectedTab === 'team' && <TeamTab seasonYear={seasonYear} seasonId={fantasyLeagueSeason?.id} userTeam={userTeam} fantasyLeague={fantasyLeague} />}
-          {selectedTab === 'schedule' && <ScheduleTab seasonId={fantasyLeagueSeason?.id} userTeamId={userTeam?.id} seasonYear={seasonYear} currentRound={fantasyLeagueSeason?.currentRound ?? null} playoffStartRound={fantasyLeagueSeason?.playoffStartRound ?? null} numberOfRounds={fantasyLeagueSeason?.numberOfRounds ?? null} />}
-          {selectedTab === 'rodada' && <RodadaTab seasonId={fantasyLeagueSeason?.id} userTeamId={userTeam?.id} seasonYear={seasonYear} currentRound={fantasyLeagueSeason?.currentRound ?? null} playoffStartRound={fantasyLeagueSeason?.playoffStartRound ?? null} numberOfRounds={fantasyLeagueSeason?.numberOfRounds ?? null} />}
+          {selectedTab === 'schedule' && <ScheduleTab seasonId={fantasyLeagueSeason?.id} userTeamId={userTeam?.id} seasonYear={seasonYear} currentRound={fantasyLeagueSeason?.currentFantasyRound ?? null} playoffStartRound={fantasyLeagueSeason?.playoffStartRound ?? null} numberOfRounds={fantasyLeagueSeason?.numberOfRounds ?? null} />}
+          {selectedTab === 'rodada' && <RodadaTab seasonId={fantasyLeagueSeason?.id} userTeamId={userTeam?.id} seasonYear={seasonYear} currentRound={fantasyLeagueSeason?.currentFantasyRound ?? null} playoffStartRound={fantasyLeagueSeason?.playoffStartRound ?? null} numberOfRounds={fantasyLeagueSeason?.numberOfRounds ?? null} />}
           {selectedTab === 'league' && <FantasyLeagueInfo currentUserId={currentUserId} fantasyLeague={fantasyLeague} />}
           {selectedTab === 'players' && (
             <Box display="flex" flexDirection="column" gap={2}>
@@ -169,7 +169,7 @@ const FantasyLeaguePage = ({ currentUserId }: { currentUserId: number }) => {
               userTeam={userTeam}
               fantasyLeague={fantasyLeague}
               currentUserId={currentUserId}
-              currentRound={fantasyLeagueSeason?.currentRound}
+              currentFantasyRound={fantasyLeagueSeason?.currentFantasyRound}
               tradeDeadlineRound={fantasyLeagueSeason?.tradeDeadlineRound}
             />
           )}


### PR DESCRIPTION
- FantasyLeagueSeason interface: currentRound→currentFantasyRound, added currentRealRound
- TeamTabComponent, PlayersList: use currentRealRound for locked-teams and real match queries (was incorrectly passing fantasy round)
- TradesTab: prop renamed to currentFantasyRound
- SeasonStatusCard: shows both round numbers when they differ
- FantasyLeague.tsx: all prop passes updated