### PR TITLE
feat(roster): free bench slots + player filter fixes

### DIFF
--- a/src/api/useUpdateRosterSettings.ts
+++ b/src/api/useUpdateRosterSettings.ts
@@ -9,10 +9,7 @@ export interface RosterSettings {
     starterSkillSlots: number;
     minStarterMidfielders: number;
     minStarterForwards: number;
-    benchSkillSlots: number;
-    benchDefenseSlots: number;
-    minBenchMidfielders: number;
-    minBenchForwards: number;
+    benchSlots: number;
     starterDefenseSlots: number;
     defenseType: DefenseType;
 }

--- a/src/components/CreateLeagueModal.tsx
+++ b/src/components/CreateLeagueModal.tsx
@@ -45,7 +45,7 @@ interface CreateLeagueModalProps {
 const draftTypes = [
   {
     value: 'snake',
-    label: 'Cobra',
+    label: 'Vai e Vem',
     description: 'O time que escolher primeiro na primeira rodada escolhe por último na segunda rodada e assim por diante.',
   },
   {

--- a/src/components/PlayerSelectModal.tsx
+++ b/src/components/PlayerSelectModal.tsx
@@ -16,13 +16,17 @@ import {
   TablePagination,
   IconButton,
   InputAdornment,
+  MenuItem,
+  Select,
+  FormControl,
+  InputLabel,
   useTheme,
   useMediaQuery,
   Snackbar,
   Alert,
 } from '@mui/material';
 import ClearIcon from '@mui/icons-material/Clear';
-import { Player, usePlayers } from '../api/playersQueries';
+import { Player, usePlayers, usePlayersFilters } from '../api/playersQueries';
 import { useAddPlayer } from '../api/userTeamRosterMutations';
 import { FantasyLeague } from '../api/fantasyLeagueQueries';
 import Loading from './Loading';
@@ -35,7 +39,7 @@ export const POSITIONS_TRANSLATION = {
   Defense: 'Defesa',
 };
 
-const POSITIONS_BACKEND_MAP = {
+const POSITIONS_BACKEND_MAP: Record<string, string> = {
   DEF: 'Defense',
   MEI: 'Midfielder',
   ATA: 'Attacker',
@@ -72,6 +76,7 @@ const PlayerSelectModal: React.FC<PlayerSelectModalProps> = ({
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   const [position, setPosition] = useState<string>('ALL');
+  const [teamId, setTeamId] = useState<number | ''>('');
   const [search, setSearch] = useState<string>('');
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
@@ -81,12 +86,27 @@ const PlayerSelectModal: React.FC<PlayerSelectModalProps> = ({
     type: 'success',
   });
 
+  // Reset filters when modal opens
+  useEffect(() => {
+    if (open) {
+      setPosition('ALL');
+      setTeamId('');
+      setSearch('');
+      setPage(0);
+    }
+  }, [open]);
+
   const { mutate: addPlayer, isPending: isAddingPlayer } = useAddPlayer({
     onSuccess: () => {
-      setSnackbar({ open: true, message: 'Player added to roster!', type: 'success' });
+      setSnackbar({ open: true, message: 'Jogador adicionado ao elenco!', type: 'success' });
       refetch();
       onClose();
     },
+  });
+
+  const { data: filtersData } = usePlayersFilters({
+    leagueId: fantasyLeague.league.externalId,
+    seasonYear,
   });
 
   const handlePlayerClick = (playerId: number) => {
@@ -102,12 +122,14 @@ const PlayerSelectModal: React.FC<PlayerSelectModalProps> = ({
     });
   };
 
-  const backendPosition = allowedPositions.map(
-    (pos) => POSITIONS_BACKEND_MAP[pos as keyof typeof POSITIONS_BACKEND_MAP]
-  );
+  // Resolve which positions to send to the API based on the selected filter
+  const resolvedPositions: string[] =
+    position === 'ALL'
+      ? allowedPositions.map((pos) => POSITIONS_BACKEND_MAP[pos] ?? pos)
+      : [POSITIONS_BACKEND_MAP[position] ?? position];
 
   const { data, isLoading } = usePlayers({
-    position: backendPosition,
+    position: resolvedPositions,
     search,
     page: page + 1,
     limit: rowsPerPage,
@@ -115,10 +137,10 @@ const PlayerSelectModal: React.FC<PlayerSelectModalProps> = ({
     order: 'desc',
     leagueId: fantasyLeague.league.id,
     fantasyLeagueId: fantasyLeague.id,
-    onlyFreeAgents: true, 
+    onlyFreeAgents: true,
+    teamId: teamId !== '' ? teamId : undefined,
   });
 
-  // 🔁 Cache the last successful data to prevent blinking
   const previousDataRef = useRef<Player[]>([]);
   useEffect(() => {
     if (data?.data?.length) {
@@ -136,19 +158,26 @@ const PlayerSelectModal: React.FC<PlayerSelectModalProps> = ({
   };
 
   if (isAddingPlayer) return <Loading message="Adicionando jogador..." />;
-  if (isLoading) return <Loading message="Carregando jogadores..." fullScreen />;
+  if (isLoading && !previousDataRef.current.length) return <Loading message="Carregando jogadores..." fullScreen />;
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
       <DialogTitle>Selecionar Jogador</DialogTitle>
       <DialogContent>
-        <Box display="flex" flexDirection={isMobile ? 'column' : 'row'} gap={2} mb={3}>
+        <Box display="flex" flexDirection={isMobile ? 'column' : 'row'} gap={2} mb={3} flexWrap="wrap">
+          {/* Position filter */}
           <ToggleButtonGroup
             value={position}
             exclusive
-            onChange={(_, newPos) => newPos && setPosition(newPos)}
+            onChange={(_, newPos) => {
+              if (newPos) {
+                setPosition(newPos);
+                setPage(0);
+              }
+            }}
             size="small"
           >
+            <ToggleButton value="ALL">Todos</ToggleButton>
             {allowedPositions.map((pos) => (
               <ToggleButton key={pos} value={pos}>
                 {pos}
@@ -156,6 +185,27 @@ const PlayerSelectModal: React.FC<PlayerSelectModalProps> = ({
             ))}
           </ToggleButtonGroup>
 
+          {/* Team filter */}
+          <FormControl size="small" sx={{ minWidth: 160 }}>
+            <InputLabel>Time</InputLabel>
+            <Select
+              value={teamId}
+              label="Time"
+              onChange={(e) => {
+                setTeamId(e.target.value as number | '');
+                setPage(0);
+              }}
+            >
+              <MenuItem value="">Todos os times</MenuItem>
+              {(filtersData?.teams ?? []).map((t) => (
+                <MenuItem key={t.id} value={t.id}>
+                  {t.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          {/* Search */}
           <TextField
             placeholder="Buscar jogador"
             size="small"
@@ -177,12 +227,7 @@ const PlayerSelectModal: React.FC<PlayerSelectModalProps> = ({
           />
         </Box>
 
-        <Box
-          sx={{
-            opacity: isLoading ? 0.6 : 1,
-            transition: 'opacity 300ms ease-in-out',
-          }}
-        >
+        <Box sx={{ opacity: isLoading ? 0.6 : 1, transition: 'opacity 300ms ease-in-out' }}>
           <Table size="small">
             <TableHead>
               <TableRow>
@@ -209,7 +254,7 @@ const PlayerSelectModal: React.FC<PlayerSelectModalProps> = ({
                     </TableCell>
                     <TableCell>{player.team_name}</TableCell>
                     <TableCell>
-                      {POSITIONS_TRANSLATION[player.player_position as keyof typeof POSITIONS_TRANSLATION]}
+                      {POSITIONS_TRANSLATION[player.player_position as keyof typeof POSITIONS_TRANSLATION] ?? player.player_position}
                     </TableCell>
                     <TableCell align="right">{player.goals}</TableCell>
                   </TableRow>

--- a/src/components/PlayersList.tsx
+++ b/src/components/PlayersList.tsx
@@ -201,7 +201,7 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
     limit: rowsPerPage,
     sortBy,
     order,
-    leagueId: fantasyLeague.league.id,
+    leagueId: fantasyLeague.league.externalId,
     fantasyLeagueId: fantasyLeague.id,
     onlyFreeAgents,
   });
@@ -228,7 +228,7 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
   };
 
   const { data: filters, isLoading: loadingFilters } = usePlayersFilters({
-    leagueId: fantasyLeague.league.id,
+    leagueId: fantasyLeague.league.externalId,
     seasonYear,
   });
   

--- a/src/components/RosterSettingsForm.tsx
+++ b/src/components/RosterSettingsForm.tsx
@@ -39,9 +39,6 @@ const RosterSettingsForm: React.FC<Props> = ({ values, onChange, id, refetchRost
   const totalStarterMin = values.minStarterMidfielders + values.minStarterForwards;
   const isStarterTotalExceeded = totalStarterMin > values.starterSkillSlots;
 
-  const totalBenchMin = values.minBenchMidfielders + values.minBenchForwards;
-  const isBenchTotalExceeded = totalBenchMin > values.benchSkillSlots;
-
   return (
     <>
       {isLocked && (
@@ -49,6 +46,7 @@ const RosterSettingsForm: React.FC<Props> = ({ values, onChange, id, refetchRost
           Configurações de elenco bloqueadas — o draft já foi agendado.
         </Alert>
       )}
+
       {/* Starter Settings */}
       <Typography fontWeight={600} sx={{ mb: 2, fontSize: '1.2rem' }}>Jogadores Titulares</Typography>
       <Box>
@@ -69,7 +67,7 @@ const RosterSettingsForm: React.FC<Props> = ({ values, onChange, id, refetchRost
       </Box>
 
       <Box>
-        <Typography fontWeight={600}>Minimo de Meio-campistas Titulares</Typography>
+        <Typography fontWeight={600}>Mínimo de Meio-campistas Titulares</Typography>
         <TextField
           fullWidth
           type="number"
@@ -89,7 +87,7 @@ const RosterSettingsForm: React.FC<Props> = ({ values, onChange, id, refetchRost
       </Box>
 
       <Box>
-        <Typography fontWeight={600}>Minimo de Atacantes Titulares</Typography>
+        <Typography fontWeight={600}>Mínimo de Atacantes Titulares</Typography>
         <TextField
           fullWidth
           type="number"
@@ -107,6 +105,7 @@ const RosterSettingsForm: React.FC<Props> = ({ values, onChange, id, refetchRost
           }
         />
       </Box>
+
       <Box>
         <Typography fontWeight={600}>Defesa(s) Titular(es)</Typography>
         <TextField
@@ -123,73 +122,28 @@ const RosterSettingsForm: React.FC<Props> = ({ values, onChange, id, refetchRost
         />
       </Box>
 
-      <Typography fontWeight={600} sx={{ my: 2, fontSize: '1.2rem' }}>Jogadores Reserva</Typography>
       {/* Bench Settings */}
+      <Typography fontWeight={600} sx={{ my: 2, fontSize: '1.2rem' }}>Jogadores Reserva</Typography>
       <Box>
-        <Typography fontWeight={600}>Total de Jogadores Reserva (não incluindo defesa)</Typography>
+        <Typography fontWeight={600}>Vagas no Banco</Typography>
+        <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+          O banco é livre — qualquer posição pode ocupar qualquer vaga.
+        </Typography>
         <TextField
           fullWidth
           type="number"
+          inputProps={{ min: 1, max: 10 }}
           disabled={isLocked}
-          value={values.benchSkillSlots}
-          onChange={(e) => onChange('benchSkillSlots', Number(e.target.value))}
+          value={values.benchSlots}
+          onChange={(e) => {
+            const value = Number(e.target.value);
+            if (value >= 1 && value <= 10) {
+              onChange('benchSlots', value);
+            }
+          }}
         />
       </Box>
 
-      <Box>
-        <Typography fontWeight={600}>Minimo de Meio-campistas Reservas</Typography>
-        <TextField
-          fullWidth
-          type="number"
-          disabled={isLocked}
-          value={values.minBenchMidfielders}
-          onChange={(e) => {
-            const value = Number(e.target.value);
-            if (value >= 0 && value <= values.benchSkillSlots) {
-              onChange('minBenchMidfielders', value);
-            }
-          }}
-          error={isBenchTotalExceeded}
-          helperText={
-            isBenchTotalExceeded ? 'A soma dos atacantes e meias não pode exceder o total de jogadores reservas' : ''
-          }
-        />
-      </Box>
-
-      <Box>
-        <Typography fontWeight={600}>Atacantes Reserva (mín)</Typography>
-        <TextField
-          fullWidth
-          type="number"
-          disabled={isLocked}
-          value={values.minBenchForwards}
-          onChange={(e) => {
-            const value = Number(e.target.value);
-            if (value >= 0 && value <= values.benchSkillSlots) {
-              onChange('minBenchForwards', value);
-            }
-          }}
-          error={isBenchTotalExceeded}
-          helperText={
-            isBenchTotalExceeded ? 'A soma dos atacantes e meias não pode exceder o total de jogadores reservas' : ''
-          }
-        />
-      </Box>
-      <Box>
-        <Typography fontWeight={600}>Maximo de Defesa(s) Reserva(s)</Typography>
-        <TextField
-          fullWidth
-          type="number"
-          disabled={isLocked}
-          value={values.benchDefenseSlots}
-          onChange={(e) => {
-            const value = Number(e.target.value);
-            if (value >= 0 && value <= 2) {
-              onChange('benchDefenseSlots', value);
-            }
-          }}
-        />
-      </Box>
       <Box sx={{ mt: 2 }}>
         <Typography fontWeight={600} sx={{ mb: 1 }}>Tipo de Defesa</Typography>
         <ToggleButtonGroup
@@ -215,16 +169,17 @@ const RosterSettingsForm: React.FC<Props> = ({ values, onChange, id, refetchRost
           p: 2,
           display: 'flex',
           justifyContent: 'flex-end',
-      }}
-        >
-      <Button
-        variant="contained"
-        onClick={() => updateRoster.mutate({ id, updates: values })}
-        disabled={updateRoster.isPending || isStarterTotalExceeded || isBenchTotalExceeded || isLocked}
+        }}
       >
-        Salvar
-      </Button>
+        <Button
+          variant="contained"
+          onClick={() => updateRoster.mutate({ id, updates: values })}
+          disabled={updateRoster.isPending || isStarterTotalExceeded || isLocked}
+        >
+          Salvar
+        </Button>
       </Box>
+
       <Snackbar open={openSnackbar} autoHideDuration={3000} onClose={() => setOpenSnackbar(false)}>
         <Alert severity="success" sx={{ width: '100%' }}>
           Configurações salvas com sucesso!

--- a/src/components/SlotCard.tsx
+++ b/src/components/SlotCard.tsx
@@ -31,9 +31,11 @@ export enum RosterSlotCard {
   };
 
   export const SlotCard: React.FC<SlotCardProps> = ({ slotType, allowedPositions, player, onRemovePlayer, slot, opponentInfo }) => {
-    const label = allowedPositions.length > 1
-      ? allowedPositions.map((p) => p === 'MEI' ? 'M' : p === 'ATA' ? 'A' : p).join('/')
-      : allowedPositions[0];
+    const label = slotType === 'bench'
+      ? 'BN'
+      : allowedPositions.length > 1
+        ? allowedPositions.map((p) => p === 'MEI' ? 'M' : p === 'ATA' ? 'A' : p).join('/')
+        : allowedPositions[0];
   
     return (
       <Paper


### PR DESCRIPTION
Bench section in RosterSettingsForm reduced to a single slot count input. SlotCard shows BN label for bench slots (gray chip). PlayerSelectModal gets a working position filter, Todos tab, and team dropdown. Both PlayerSelectModal and PlayersList now pass league.externalId (not .id) to player/filter queries.