### PR TITLE
feat(rounds): round calendar UI, real-round displays, creation guards

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -75,6 +75,14 @@ const endpoints = {
     validateConfig: `${API_BASE_URL}/fantasy-matchups/validate-config`,
     delete: (seasonId: string) => `${API_BASE_URL}/fantasy-matchups/season/${seasonId}`,
   },
+  roundMappings: {
+    calendar: (seasonId: string) =>
+      `${API_BASE_URL}/fantasy-matchups/season/${seasonId}/round-calendar`,
+    skip: (seasonId: string, realRound: number) =>
+      `${API_BASE_URL}/fantasy-matchups/season/${seasonId}/skip/${realRound}`,
+    unskip: (seasonId: string, realRound: number) =>
+      `${API_BASE_URL}/fantasy-matchups/season/${seasonId}/unskip/${realRound}`,
+  },
   fantasyRoundGames: {
     lockedTeams: (leagueExternalId: number, seasonYear: number, roundNumber: number) =>
       `${API_BASE_URL}/fantasy-round-games/league/${leagueExternalId}/season/${seasonYear}/round/${roundNumber}/locked-teams`,

--- a/src/api/fantasyLeagueMutations.ts
+++ b/src/api/fantasyLeagueMutations.ts
@@ -8,6 +8,7 @@ interface CreateFantasyLeagueData {
   ownerId: number;
   leagueId: number;
   draftType: string;
+  numberOfRounds?: number;
 }
 
 export interface UpdateFantasyLeague {

--- a/src/api/fantasyMatchupQueries.ts
+++ b/src/api/fantasyMatchupQueries.ts
@@ -5,6 +5,8 @@ import { apiConfig } from './config';
 export interface FantasyMatchupDto {
   id: string;
   roundNumber: number;
+  // Real-league round this fantasy round maps to (equals roundNumber unless skipped)
+  realRound: number;
   homeTeamId: number | null;
   homeTeamName: string | null;
   homeOwnerName: string | null;

--- a/src/api/fantasyRoundGameQueries.ts
+++ b/src/api/fantasyRoundGameQueries.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import { apiConfig } from './config';
 
@@ -60,6 +60,37 @@ export const useListRoundMatches = (
     enabled: !!leagueExternalId && !!seasonYear && roundNumber != null,
     staleTime: 0,
   });
+
+// Fetches all rounds in parallel and returns a map of realRound → non-PST match count.
+// Used by RoundCalendar to flag rounds with fewer than 10 confirmed games.
+export const useAllRoundsMatchCounts = (
+  leagueExternalId: number | undefined,
+  seasonYear: number | undefined,
+  realRounds: number[],
+): Map<number, number> => {
+  const results = useQueries({
+    queries: realRounds.map((round) => ({
+      queryKey: ['roundGameMatches', leagueExternalId, seasonYear, round],
+      queryFn: async () => {
+        const res = await axios.get(
+          apiConfig.endpoints.fantasyRoundGames.listMatches(leagueExternalId!, seasonYear!, round),
+          { headers: authHeader() },
+        );
+        return { round, matches: res.data as RoundGameMatch[] };
+      },
+      enabled: !!leagueExternalId && !!seasonYear,
+      staleTime: 0,
+    })),
+  });
+
+  const map = new Map<number, number>();
+  for (const r of results) {
+    if (r.data) {
+      map.set(r.data.round, r.data.matches.filter((m) => m.status !== 'PST').length);
+    }
+  }
+  return map;
+};
 
 export const useOrphanedMatches = (
   leagueExternalId: number | undefined,

--- a/src/api/roundMappingQueries.ts
+++ b/src/api/roundMappingQueries.ts
@@ -1,0 +1,81 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
+import { apiConfig } from './config';
+
+export type RoundCalendarRowStatus =
+  | 'FINISHED'
+  | 'CURRENT'
+  | 'SKIPPED'
+  | 'UPCOMING';
+
+export interface RoundCalendarRow {
+  fantasyRound: number | null;
+  realRound: number;
+  status: RoundCalendarRowStatus;
+  isPlayoffRound: boolean;
+  firstKickoffAt: string | null;
+  canSkip: boolean;
+  canUnskip: boolean;
+}
+
+export interface RoundCalendar {
+  seasonId: string;
+  startRound: number;
+  numberOfRounds: number;
+  playoffStartRound: number | null;
+  currentFantasyRound: number | null;
+  realCurrentRound: number | null;
+  maxRealRound: number;
+  lastMappedRealRound: number | null;
+  remainingMargin: number;
+  rows: RoundCalendarRow[];
+}
+
+const authHeader = () => ({
+  Authorization: `Bearer ${localStorage.getItem('token')}`,
+});
+
+export const useRoundCalendar = (seasonId: string | undefined) =>
+  useQuery<RoundCalendar>({
+    queryKey: ['roundCalendar', seasonId],
+    queryFn: async () => {
+      const res = await axios.get(
+        apiConfig.endpoints.roundMappings.calendar(seasonId!),
+        { headers: authHeader() },
+      );
+      return res.data;
+    },
+    enabled: !!seasonId,
+  });
+
+const useRoundMappingMutation = (
+  url: (seasonId: string, realRound: number) => string,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      seasonId,
+      realRound,
+    }: {
+      seasonId: string;
+      realRound: number;
+    }) => {
+      const res = await axios.post(url(seasonId, realRound), null, {
+        headers: authHeader(),
+      });
+      return res.data as RoundCalendar;
+    },
+    onSuccess: (_data, { seasonId }) => {
+      queryClient.invalidateQueries({ queryKey: ['roundCalendar', seasonId] });
+      queryClient.invalidateQueries({ queryKey: ['fantasyLeagueSeasons'] });
+      queryClient.invalidateQueries({ queryKey: ['fantasyMatchups', seasonId] });
+      queryClient.invalidateQueries({ queryKey: ['playoffs', seasonId] });
+    },
+  });
+};
+
+export const useSkipRound = () =>
+  useRoundMappingMutation(apiConfig.endpoints.roundMappings.skip);
+
+export const useUnskipRound = () =>
+  useRoundMappingMutation(apiConfig.endpoints.roundMappings.unskip);

--- a/src/api/useFantasyLeagueSeasons.ts
+++ b/src/api/useFantasyLeagueSeasons.ts
@@ -17,6 +17,11 @@ export interface FantasyLeagueSeason {
   seasonYear: number;
   currentFantasyRound: number | null;
   currentRealRound: number | null;
+  // Real-league round tracker + skip budget (round calendar feature)
+  realCurrentRound: number | null;
+  maxRealRound: number;
+  lastMappedRealRound: number | null;
+  remainingSkipMargin: number | null;
   waiverSystem: 'AUCTION' | 'PRIORITY';
   initialWaiverBudget: number;
   fantasyLeague?: { league?: { externalId?: number } };

--- a/src/components/CreateLeagueModal.tsx
+++ b/src/components/CreateLeagueModal.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
+  Alert,
   Box,
   Typography,
   Button,
@@ -37,9 +38,15 @@ const modalStyle = {
   borderRadius: 3,
 };
 
+const CREATION_CUTOFF_ROUND = 26;
+const DEFAULT_ROUNDS = 19;
+const MIN_ROUNDS = 12;
+
 interface CreateLeagueModalProps {
   open: boolean;
   handleClose: () => void;
+  realCurrentRound?: number | null;
+  maxRealRound?: number | null;
 }
 
 const draftTypes = [
@@ -55,12 +62,37 @@ const draftTypes = [
   },
 ];
 
-const CreateLeagueModal: React.FC<CreateLeagueModalProps> = ({ open, handleClose }) => {
+const CreateLeagueModal: React.FC<CreateLeagueModalProps> = ({ open, handleClose, realCurrentRound, maxRealRound }) => {
   const { user } = useAuth();
   const [leagueName, setLeagueName] = useState('');
   const [numberOfTeams, setNumberOfTeams] = useState(8);
   const [draftType, setDraftType] = useState('snake');
   const { mutate: createFantasyLeague, isPending, isError, error } = useCreateFantasyLeague();
+
+  const maxAllowed = useMemo(() => {
+    if (maxRealRound != null && realCurrentRound != null) {
+      return maxRealRound - realCurrentRound + 1;
+    }
+    return null;
+  }, [maxRealRound, realCurrentRound]);
+
+  const roundOptions = useMemo(() => {
+    const all = Array.from({ length: 20 }, (_, i) => MIN_ROUNDS + i);
+    return maxAllowed != null ? all.filter((v) => v <= maxAllowed) : all;
+  }, [maxAllowed]);
+
+  const [numberOfRounds, setNumberOfRounds] = useState(() =>
+    Math.min(DEFAULT_ROUNDS, maxAllowed ?? DEFAULT_ROUNDS),
+  );
+
+  // Recalculate default when real round info loads
+  React.useEffect(() => {
+    if (maxAllowed != null) {
+      setNumberOfRounds((prev) => Math.min(prev, maxAllowed));
+    }
+  }, [maxAllowed]);
+
+  const isPastCutoff = realCurrentRound != null && realCurrentRound > CREATION_CUTOFF_ROUND;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -73,6 +105,7 @@ const CreateLeagueModal: React.FC<CreateLeagueModalProps> = ({ open, handleClose
         ownerId: Number(user?.id) || 0,
         leagueId: 1,
         draftType,
+        numberOfRounds,
       },
       {
         onSuccess: handleClose,
@@ -89,6 +122,11 @@ const CreateLeagueModal: React.FC<CreateLeagueModalProps> = ({ open, handleClose
           Criar Nova Liga
         </Typography>
 
+        {isPastCutoff ? (
+          <Alert severity="warning">
+            Não é possível criar novas ligas após a rodada {CREATION_CUTOFF_ROUND} do campeonato. Aguarde a próxima temporada.
+          </Alert>
+        ) : (
         <form onSubmit={handleSubmit}>
           <Stack spacing={3}>
             <TextField
@@ -152,6 +190,23 @@ const CreateLeagueModal: React.FC<CreateLeagueModalProps> = ({ open, handleClose
               </RadioGroup>
             </FormControl>
 
+            <TextField
+              select
+              label="Número de Rodadas"
+              value={numberOfRounds}
+              onChange={(e) => setNumberOfRounds(Number(e.target.value))}
+              fullWidth
+              helperText={
+                maxAllowed != null && maxAllowed < DEFAULT_ROUNDS
+                  ? `Máximo disponível no campeonato: ${maxAllowed} rodadas`
+                  : undefined
+              }
+            >
+              {roundOptions.map((n) => (
+                <MenuItem key={n} value={n}>{n}</MenuItem>
+              ))}
+            </TextField>
+
             <Stack direction="row" spacing={2} justifyContent="flex-end" mt={1}>
               <Button onClick={handleClose} variant="outlined">
                 Cancelar
@@ -166,6 +221,7 @@ const CreateLeagueModal: React.FC<CreateLeagueModalProps> = ({ open, handleClose
             </Stack>
           </Stack>
         </form>
+        )}
 
         {isError && (
           <Typography color="error" sx={{ mt: 2 }}>

--- a/src/components/FantasyLeagueInfo.tsx
+++ b/src/components/FantasyLeagueInfo.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
+import { Alert } from '@mui/material';
 import FantasyLeagueTeams from './FantasyLeagueTeams';
 import FantasyLeagueSettings from './FantasyLeagueSettings';
+import RoundCalendar from './RoundCalendar';
 import { FantasyLeague } from '../api/fantasyLeagueQueries';
+import { useFantasyLeagueSeasons } from '../api/useFantasyLeagueSeasons';
+
+const PRE_DRAFT_STATUSES = ['INACTIVE', 'ACTIVATED_PRESEASON', 'DRAFT_SCHEDULED'];
 
 interface Props {
 
@@ -10,10 +15,40 @@ interface Props {
 }
 
 const FantasyLeagueInfo: React.FC<Props> = ({ currentUserId, fantasyLeague}) => {
+    const { data: fantasyLeagueSeason } = useFantasyLeagueSeasons(fantasyLeague.id);
+    const isOwner = fantasyLeague.owner?.id === currentUserId;
+
+    // Pre-draft leagues with no round margin: drafting too late forces an automatic reduction
+    const maxAvailableRounds =
+        fantasyLeagueSeason?.realCurrentRound != null && fantasyLeagueSeason.maxRealRound > 0
+            ? fantasyLeagueSeason.maxRealRound - fantasyLeagueSeason.realCurrentRound + 1
+            : null;
+    const showDraftDeadlineWarning =
+        isOwner &&
+        !!fantasyLeagueSeason &&
+        PRE_DRAFT_STATUSES.includes(fantasyLeagueSeason.status) &&
+        maxAvailableRounds != null &&
+        fantasyLeagueSeason.numberOfRounds >= maxAvailableRounds;
+    const draftCutoffRound = fantasyLeagueSeason
+        ? fantasyLeagueSeason.maxRealRound - fantasyLeagueSeason.numberOfRounds + 2
+        : null;
+
     return (
         <>
+            {showDraftDeadlineWarning && (
+                <Alert severity="warning" sx={{ mt: 2 }}>
+                    O draft precisa ocorrer antes da rodada {draftCutoffRound} do campeonato.
+                    Caso contrário, o número de rodadas da liga será reduzido automaticamente
+                    {maxAvailableRounds != null && maxAvailableRounds < fantasyLeagueSeason!.numberOfRounds
+                        ? ` para ${maxAvailableRounds}`
+                        : ''}.
+                </Alert>
+            )}
             <FantasyLeagueTeams fantasyLeague={fantasyLeague} />
-            <FantasyLeagueSettings isOwner={fantasyLeague.owner?.id === currentUserId} fantasyLeague={fantasyLeague} />
+            {fantasyLeagueSeason && (
+                <RoundCalendar fantasyLeagueSeason={fantasyLeagueSeason} isOwner={isOwner} />
+            )}
+            <FantasyLeagueSettings isOwner={isOwner} fantasyLeague={fantasyLeague} />
         </>
     );
 };

--- a/src/components/FantasyLeagueSeasonForm.tsx
+++ b/src/components/FantasyLeagueSeasonForm.tsx
@@ -25,11 +25,17 @@ interface Props {
   id: any;
   refetchFantasyLeagueSeason: () => void;
   seasonStatus?: string;
+  maxRealRound?: number | null;
 }
 
-const FantasyLeagueSeasonForm: React.FC<Props> = ({ values, onChange, id, refetchFantasyLeagueSeason, seasonStatus }) => {
+const FantasyLeagueSeasonForm: React.FC<Props> = ({ values, onChange, id, refetchFantasyLeagueSeason, seasonStatus, maxRealRound }) => {
   const isLocked = !!seasonStatus && SEASON_LOCKED_STATUSES.includes(seasonStatus);
   const [openSnackbar, setOpenSnackbar] = useState(false);
+  // The fantasy season can't need more rounds than the championship has left
+  const roundOptions = useMemo(() => {
+    const all = Array.from({ length: 20 }, (_, i) => 12 + i);
+    return maxRealRound ? all.filter((v) => v <= maxRealRound) : all;
+  }, [maxRealRound]);
   const tradeDeadlineOptions = useMemo(() => {
     const start = Math.max(1, values.numberOfRounds - 8);
     const end = values.numberOfRounds - 3;
@@ -92,13 +98,18 @@ const FantasyLeagueSeasonForm: React.FC<Props> = ({ values, onChange, id, refetc
       {/* Número de Rodadas */}
       <Box>
         <Typography fontWeight={600}>Número de Rodadas</Typography>
+        {maxRealRound != null && (
+          <Typography variant="body2" color="text.secondary">
+            Máximo permitido pelo calendário do campeonato: {maxRealRound}.
+          </Typography>
+        )}
         <FormControl fullWidth>
           <Select
             value={values.numberOfRounds ?? ''}
             onChange={(e) => onChange('numberOfRounds', e.target.value)}
             disabled={isLocked}
           >
-            {Array.from({ length: 20 }, (_, i) => 12 + i).map((val) => (
+            {roundOptions.map((val) => (
               <MenuItem key={val} value={val}>
                 {val}
               </MenuItem>

--- a/src/components/FantasyLeagueSettingsModal.tsx
+++ b/src/components/FantasyLeagueSettingsModal.tsx
@@ -114,6 +114,7 @@ const FantasyLeagueSettingsModal: React.FC<Props> = ({ open, onClose, fantasyLea
             id={fantasyLeagueSeason?.id!}
             refetchFantasyLeagueSeason={refetchFantasyLeagueSeason}
             seasonStatus={fantasyLeagueSeason?.status}
+            maxRealRound={fantasyLeagueSeason?.maxRealRound}
           />
         );
       case 'roster':

--- a/src/components/MatchupDetailModal.tsx
+++ b/src/components/MatchupDetailModal.tsx
@@ -208,7 +208,11 @@ export interface MatchupDetailProps {
 export const MatchupDetail: React.FC<MatchupDetailProps> = ({ matchup, userTeamId, seasonYear, seasonId }) => {
   const isCompleted = matchup.status === 'completed';
 
-  const { data: realMatches } = useRealMatchesByRound(seasonYear, matchup.roundNumber);
+  // Real-world data (games, player history) lives under the REAL round, which
+  // differs from the fantasy round when the league skipped a championship round
+  const realRound = matchup.realRound ?? matchup.roundNumber;
+
+  const { data: realMatches } = useRealMatchesByRound(seasonYear, realRound);
   const { data: pointsMap } = usePointsByRound(
     isCompleted ? undefined : seasonId,
     matchup.roundNumber,
@@ -278,7 +282,7 @@ export const MatchupDetail: React.FC<MatchupDetailProps> = ({ matchup, userTeamI
         playerName={statsSlot?.name}
         playerPhoto={statsSlot?.photo}
         seasonId={seasonId}
-        roundFilter={matchup.roundNumber}
+        roundFilter={realRound}
         opponentInfo={statsSlot?.opponentInfo}
         onClose={() => setStatsSlot(null)}
       />

--- a/src/components/RodadaTab.tsx
+++ b/src/components/RodadaTab.tsx
@@ -220,6 +220,9 @@ const RodadaTab: React.FC<Props> = ({
     ? [myMatchup, ...allMatchups.filter((m) => m.id !== myMatchup.id)]
     : allMatchups;
 
+  // Real championship round this fantasy round maps to (differs after a skip)
+  const activeRealRound = allMatchups[0]?.realRound ?? activeRound;
+
   // Default expansion: user's matchup open on mount / round change
   const defaultExpandedId = myMatchup?.id ?? orderedMatchups[0]?.id ?? null;
   const expandedId = expandedMatchupId !== undefined ? expandedMatchupId : defaultExpandedId;
@@ -278,6 +281,12 @@ const RodadaTab: React.FC<Props> = ({
         >
           <ArrowForwardIosIcon fontSize="small" />
         </IconButton>
+
+        {activeRealRound !== activeRound && (
+          <Typography variant="body2" color="text.secondary">
+            {activeRealRound} do Brasileirao
+          </Typography>
+        )}
       </Stack>
 
       {/* Matchup list — stable order, expand/collapse in place */}

--- a/src/components/RoundCalendar.tsx
+++ b/src/components/RoundCalendar.tsx
@@ -1,0 +1,341 @@
+import React, { useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Collapse,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  Paper,
+  Snackbar,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import {
+  RoundCalendarRow,
+  useRoundCalendar,
+  useSkipRound,
+  useUnskipRound,
+} from '../api/roundMappingQueries';
+import { useAllRoundsMatchCounts, useListRoundMatches } from '../api/fantasyRoundGameQueries';
+import { FantasyLeagueSeason } from '../api/useFantasyLeagueSeasons';
+
+const getErrorMessage = (err: unknown): string => {
+  if (typeof err === 'string') return err;
+  const e: any = err;
+  const d = e?.response?.data;
+  if (d) {
+    if (Array.isArray(d.message)) return d.message.join(', ');
+    return d.message || d.error || 'Erro desconhecido';
+  }
+  return e?.message ?? 'Erro desconhecido';
+};
+
+const STATUS_CHIP: Record<
+  RoundCalendarRow['status'],
+  { label: string; color: 'default' | 'success' | 'warning' | 'info' }
+> = {
+  FINISHED: { label: 'Encerrada', color: 'default' },
+  CURRENT: { label: 'Atual', color: 'success' },
+  SKIPPED: { label: 'Pulada', color: 'warning' },
+  UPCOMING: { label: 'Futura', color: 'info' },
+};
+
+interface RoundMatchesListProps {
+  leagueExternalId: number | undefined;
+  seasonYear: number;
+  realRound: number;
+}
+
+// Separate child so the matches query only fires when the row is expanded
+const RoundMatchesList: React.FC<RoundMatchesListProps> = ({
+  leagueExternalId,
+  seasonYear,
+  realRound,
+}) => {
+  const { data: matches, isLoading } = useListRoundMatches(
+    leagueExternalId,
+    seasonYear,
+    realRound,
+  );
+
+  if (isLoading) {
+    return (
+      <Box display="flex" justifyContent="center" py={2}>
+        <CircularProgress size={20} />
+      </Box>
+    );
+  }
+  if (!matches || matches.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary" sx={{ py: 1.5, px: 2 }}>
+        Nenhum jogo cadastrado para esta rodada do campeonato.
+      </Typography>
+    );
+  }
+
+  return (
+    <Box sx={{ py: 1, px: 2 }}>
+      {matches.map((m) => (
+        <Box
+          key={m.matchId}
+          display="flex"
+          alignItems="center"
+          justifyContent="space-between"
+          py={0.5}
+        >
+          <Typography variant="body2">
+            {m.homeTeam?.name ?? '?'}{' '}
+            {m.homeGoals != null && m.awayGoals != null
+              ? `${m.homeGoals} x ${m.awayGoals}`
+              : 'x'}{' '}
+            {m.awayTeam?.name ?? '?'}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            {m.status === 'PST'
+              ? 'Adiado'
+              : m.date
+                ? new Date(m.date).toLocaleString('pt-BR', {
+                    dateStyle: 'short',
+                    timeStyle: 'short',
+                  })
+                : 'Sem data'}
+            {m.venueName ? ` • ${m.venueName}` : ''}
+          </Typography>
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+interface Props {
+  fantasyLeagueSeason: FantasyLeagueSeason;
+  isOwner: boolean;
+}
+
+const RoundCalendar: React.FC<Props> = ({ fantasyLeagueSeason, isOwner }) => {
+  const { data: calendar, isLoading } = useRoundCalendar(fantasyLeagueSeason.id);
+  const skipMutation = useSkipRound();
+  const unskipMutation = useUnskipRound();
+
+  const [expandedRound, setExpandedRound] = useState<number | null>(null);
+  const [confirmAction, setConfirmAction] = useState<{
+    type: 'skip' | 'unskip';
+    realRound: number;
+  } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const leagueExternalId = fantasyLeagueSeason.fantasyLeague?.league?.externalId;
+  const seasonYear = fantasyLeagueSeason.seasonYear;
+  const isMutating = skipMutation.isPending || unskipMutation.isPending;
+
+  const allRealRounds = (calendar?.rows ?? []).map((r) => r.realRound);
+  const matchCounts = useAllRoundsMatchCounts(leagueExternalId, seasonYear, allRealRounds);
+
+  const handleConfirm = () => {
+    if (!confirmAction) return;
+    const mutation = confirmAction.type === 'skip' ? skipMutation : unskipMutation;
+    mutation.mutate(
+      { seasonId: fantasyLeagueSeason.id, realRound: confirmAction.realRound },
+      {
+        onError: (err) => setError(getErrorMessage(err)),
+        onSettled: () => setConfirmAction(null),
+      },
+    );
+  };
+
+  if (isLoading) {
+    return (
+      <Paper sx={{ p: 2, mt: 2 }}>
+        <Box display="flex" justifyContent="center" py={2}>
+          <CircularProgress size={24} />
+        </Box>
+      </Paper>
+    );
+  }
+  if (!calendar) return null;
+
+  return (
+    <Paper sx={{ p: 2, mt: 2 }}>
+      <Typography variant="h6" gutterBottom>
+        Calendário de Rodadas
+      </Typography>
+      {isOwner && calendar.rows.length > 0 && (
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          {calendar.remainingMargin > 0
+            ? `Margem restante: ${calendar.remainingMargin} rodada(s) pulável(is)`
+            : 'Margem esgotada: a temporada termina na última rodada do campeonato, não é possível pular rodadas.'}
+        </Typography>
+      )}
+
+      {calendar.rows.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          O calendário fica disponível após a geração da tabela (pós-draft).
+        </Typography>
+      ) : (
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell padding="checkbox" />
+              <TableCell>Liga</TableCell>
+              <TableCell>Brasileirao</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell>Início</TableCell>
+              {isOwner && <TableCell align="right">Ações</TableCell>}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {calendar.rows.map((row) => (
+              <React.Fragment key={row.realRound}>
+                <TableRow hover>
+                  <TableCell padding="checkbox">
+                    <IconButton
+                      size="small"
+                      onClick={() =>
+                        setExpandedRound(
+                          expandedRound === row.realRound ? null : row.realRound,
+                        )
+                      }
+                    >
+                      {expandedRound === row.realRound ? (
+                        <KeyboardArrowUpIcon />
+                      ) : (
+                        <KeyboardArrowDownIcon />
+                      )}
+                    </IconButton>
+                  </TableCell>
+                  <TableCell>
+                    {row.fantasyRound != null ? `Rodada ${row.fantasyRound}` : '—'}
+                    {row.isPlayoffRound && (
+                      <Chip
+                        label="Playoffs"
+                        size="small"
+                        color="secondary"
+                        sx={{ ml: 1 }}
+                      />
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    Rodada {row.realRound}
+                    {matchCounts.has(row.realRound) && (matchCounts.get(row.realRound) ?? 10) < 10 && (
+                      <Chip
+                        label={`${matchCounts.get(row.realRound)} jogos`}
+                        size="small"
+                        color="warning"
+                        variant="outlined"
+                        sx={{ ml: 1, fontSize: 11, height: 18 }}
+                      />
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Chip
+                      label={STATUS_CHIP[row.status].label}
+                      color={STATUS_CHIP[row.status].color}
+                      size="small"
+                    />
+                  </TableCell>
+                  <TableCell>
+                    {row.firstKickoffAt
+                      ? new Date(row.firstKickoffAt).toLocaleString('pt-BR', {
+                          dateStyle: 'short',
+                          timeStyle: 'short',
+                        })
+                      : '—'}
+                  </TableCell>
+                  {isOwner && (
+                    <TableCell align="right">
+                      {row.canSkip && (
+                        <Button
+                          size="small"
+                          color="warning"
+                          disabled={isMutating}
+                          onClick={() =>
+                            setConfirmAction({ type: 'skip', realRound: row.realRound })
+                          }
+                        >
+                          Pular
+                        </Button>
+                      )}
+                      {row.canUnskip && (
+                        <Button
+                          size="small"
+                          disabled={isMutating}
+                          onClick={() =>
+                            setConfirmAction({ type: 'unskip', realRound: row.realRound })
+                          }
+                        >
+                          Reverter
+                        </Button>
+                      )}
+                    </TableCell>
+                  )}
+                </TableRow>
+                <TableRow>
+                  <TableCell colSpan={isOwner ? 6 : 5} sx={{ p: 0, border: 0 }}>
+                    <Collapse in={expandedRound === row.realRound} unmountOnExit>
+                      <RoundMatchesList
+                        leagueExternalId={leagueExternalId}
+                        seasonYear={seasonYear}
+                        realRound={row.realRound}
+                      />
+                    </Collapse>
+                  </TableCell>
+                </TableRow>
+              </React.Fragment>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <Dialog open={!!confirmAction} onClose={() => setConfirmAction(null)}>
+        <DialogTitle>
+          {confirmAction?.type === 'skip' ? 'Pular rodada' : 'Reverter rodada pulada'}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {confirmAction?.type === 'skip'
+              ? `Pular a rodada ${confirmAction?.realRound} do campeonato? Todas as rodadas seguintes da liga serão adiadas em 1 rodada do campeonato.`
+              : `Voltar a jogar a rodada ${confirmAction?.realRound} do campeonato? Todas as rodadas seguintes da liga serão antecipadas em 1 rodada do campeonato.`}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmAction(null)} disabled={isMutating}>
+            Cancelar
+          </Button>
+          <Button
+            onClick={handleConfirm}
+            variant="contained"
+            color={confirmAction?.type === 'skip' ? 'warning' : 'primary'}
+            disabled={isMutating}
+          >
+            Confirmar
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={!!error}
+        autoHideDuration={6000}
+        onClose={() => setError(null)}
+      >
+        <Alert severity="error" onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      </Snackbar>
+    </Paper>
+  );
+};
+
+export default RoundCalendar;

--- a/src/components/SeasonStatusCard.tsx
+++ b/src/components/SeasonStatusCard.tsx
@@ -228,9 +228,14 @@ const getErrorMessage = (err: unknown) => {
 
               {phase === 'temporada' && season.currentFantasyRound != null && (
                 <Typography variant="body2" color="text.secondary">
-                  {season.currentRealRound != null && season.currentRealRound !== season.currentFantasyRound
-                    ? `Rodada ${season.currentFantasyRound} da Liga • Rodada ${season.currentRealRound} do Campeonato`
-                    : `Rodada ${season.currentFantasyRound}`}
+                  {(() => {
+                    // Always show both rounds so users know exactly where the
+                    // league AND the championship are
+                    const realRound = season.realCurrentRound ?? season.currentRealRound;
+                    return realRound != null
+                      ? `Rodada ${season.currentFantasyRound} da Liga • Rodada ${realRound} do Campeonato`
+                      : `Rodada ${season.currentFantasyRound}`;
+                  })()}
                 </Typography>
               )}
 

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import CreateLeagueModal from '../components/CreateLeagueModal';
 import { UserFantasyLeaguesList } from '../components/UserFantasyLeaguesList';
 import { useGetMyLeagues } from '../api/fantasyLeagueQueries';
+import { useFantasyLeagueSeasons } from '../api/useFantasyLeagueSeasons';
 import { apiConfig } from '../api/config';
 import { useMutation } from '@tanstack/react-query';
 import Loading from '../components/Loading';
@@ -18,6 +19,10 @@ const Welcome = () => {
   
   // Use the React Query hook
   const { data: fantasyLeagues, isLoading, isError, error } = useGetMyLeagues();
+
+  // Use first available league's season to get real-round budget info for CreateLeagueModal
+  const firstLeagueId = fantasyLeagues?.[0]?.id ?? 0; // 0 disables the query (enabled: !!leagueId)
+  const { data: firstLeagueSeason } = useFantasyLeagueSeasons(firstLeagueId);
 
 const acceptInviteMutation = useMutation({
   mutationFn: async (token: string) => {
@@ -149,9 +154,11 @@ const acceptInviteMutation = useMutation({
         )}
       </Box>
 
-      <CreateLeagueModal 
-        open={isModalOpen} 
-        handleClose={() => setIsModalOpen(false)} 
+      <CreateLeagueModal
+        open={isModalOpen}
+        handleClose={() => setIsModalOpen(false)}
+        realCurrentRound={firstLeagueSeason?.realCurrentRound ?? null}
+        maxRealRound={firstLeagueSeason?.maxRealRound ?? null}
       />
 
       {errorMessage && (


### PR DESCRIPTION
Skip round (Pular Rodada):
- RoundCalendar component in Liga tab: fantasy<->real mapping, status chips, expandable real games per round, Pular/Reverter + margin for the owner, warning chip on rounds with fewer than 10 confirmed games
- roundMappingQueries: useRoundCalendar, useSkipRound, useUnskipRound
- useAllRoundsMatchCounts: parallel per-round match fetch sharing the roundGameMatches cache

Real-round correctness:
- MatchupDetailModal and PlayerStatsModal use matchup.realRound so a skipped round's games/points are never shown
- RodadaTab shows 'Rodada X do Campeonato' when fantasy != real
- SeasonStatusCard always shows both Liga and Campeonato rounds
- FantasyLeagueSeasonForm caps numberOfRounds at maxRealRound

Mid-season creation guards:
- CreateLeagueModal: numberOfRounds selector capped to available rounds; creation alert past championship round 26
- FantasyLeagueInfo: owner banner warning of the draft deadline and automatic round reduction
- Welcome passes realCurrentRound/maxRealRound from the first league