### PR TITLE
feat(simulator): admin simulator tab and playoff bracket polish

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -159,6 +159,15 @@ const endpoints = {
     veto: (id: string) => `${API_BASE_URL}/trades/${id}/veto`,
     process: (id: string) => `${API_BASE_URL}/trades/${id}/process`,
   },
+  simulator: {
+    leagues: `${API_BASE_URL}/simulator/leagues`,
+    league: `${API_BASE_URL}/simulator/league`,
+    deleteLeague: (leagueId: number) => `${API_BASE_URL}/simulator/leagues/${leagueId}`,
+    recreateLeague: (leagueId: number) => `${API_BASE_URL}/simulator/leagues/${leagueId}/recreate`,
+    start: (seasonId: string) => `${API_BASE_URL}/simulator/seasons/${seasonId}/start`,
+    advance: (seasonId: string) => `${API_BASE_URL}/simulator/seasons/${seasonId}/advance`,
+    lockedTeams: (seasonId: string) => `${API_BASE_URL}/simulator/seasons/${seasonId}/locked-teams`,
+  },
   currentSeason: `${API_BASE_URL}/current-season`,
   usersTeamsRoster: {
     addPlayer: `${API_BASE_URL}/user-team-rosters`,

--- a/src/api/fantasyLeagueQueries.ts
+++ b/src/api/fantasyLeagueQueries.ts
@@ -19,6 +19,7 @@ export interface FantasyLeague {
     numberOfTeams: number;
     isOwner?: boolean;
     isActive?: boolean;
+    isSimulation?: boolean;
     league: {
       id: number;
       externalId: number;

--- a/src/api/fantasyMatchupQueries.ts
+++ b/src/api/fantasyMatchupQueries.ts
@@ -21,7 +21,11 @@ export interface FantasyMatchupDto {
   isGhost: boolean;
   playoffStage: number | null;
   twoLegPairId: string | null;
+  // Bracket POSITION of each side (drives layout/pairings) — NOT the team's identity seed.
   playoffSeed: { homeSeed: number; awaySeed: number } | null;
+  // The teams' true regular-season seeds, stable across the whole bracket.
+  homeTeamSeed: number | null;
+  awayTeamSeed: number | null;
 }
 
 export interface ScheduleByRoundDto {

--- a/src/api/simulatorQueries.ts
+++ b/src/api/simulatorQueries.ts
@@ -1,0 +1,214 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
+import { apiConfig } from './config';
+
+const authHeader = () => ({ Authorization: `Bearer ${localStorage.getItem('token')}` });
+
+export type SimulationFillMode = 'AUTO_FILL' | 'MANUAL_DRAFT';
+
+export type SimulationPlayoffEvent = 'BRACKET_GENERATED' | 'ADVANCED' | 'CHAMPION' | null;
+
+export interface SimulationState {
+  leagueId: number;
+  leagueName: string;
+  seasonId: string;
+  seasonYear: number;
+  status: string;
+  fillMode: SimulationFillMode | null;
+  numberOfTeams: number;
+  numberOfRounds: number;
+  playoffStartRound: number | null;
+  currentFantasyRound: number | null;
+  currentRealRound: number | null;
+  maxAvailableRealRound: number;
+  championTeamId: number | null;
+  championTeamName: string | null;
+}
+
+export interface SimulationMatchup {
+  id: string;
+  roundNumber: number;
+  homeTeamId: number | null;
+  homeTeamName: string | null;
+  awayTeamId: number | null;
+  awayTeamName: string | null;
+  homeScore: number | null;
+  awayScore: number | null;
+  winnerId: number | null;
+  status: string;
+  isGhost: boolean;
+}
+
+export interface AdvanceRoundResult {
+  fantasyRound: number;
+  realRound: number;
+  matchups: SimulationMatchup[];
+  playoffEvent: SimulationPlayoffEvent;
+  championTeamId: number | null;
+  seasonStatus: string;
+  nextFantasyRound: number | null;
+}
+
+export interface AdvanceSimulationResponse {
+  results: AdvanceRoundResult[];
+  error: string | null;
+  state: SimulationState;
+}
+
+export type SimulationDefenseType = 'CLOSED' | 'OPEN';
+
+export type SimulationPlayoffFormat =
+  | 'single_game'
+  | 'two_leg_single_game_final'
+  | 'two_leg_all';
+
+export interface CreateSimulationLeagueInput {
+  name: string;
+  numberOfTeams: number;
+  numberOfRounds?: number;
+  fillMode: SimulationFillMode;
+  defenseType?: SimulationDefenseType;
+  playoffTeams?: number;
+  playoffFormat?: SimulationPlayoffFormat;
+}
+
+export interface SimulationLockedTeam {
+  id: number;
+  name: string;
+  logoUrl: string | null;
+  locked: boolean;
+}
+
+// Query keys the league pages depend on — invalidated after every sim mutation
+// so the normal league UI reflects advances immediately
+const LEAGUE_PAGE_KEYS = [
+  ['myLeagues'],
+  ['fantasyMatchups'],
+  ['fantasyLeagueSeasons'],
+  ['standings'],
+  ['roundCalendar'],
+];
+
+function invalidateLeaguePages(qc: ReturnType<typeof useQueryClient>) {
+  qc.invalidateQueries({ queryKey: ['simulation'] });
+  LEAGUE_PAGE_KEYS.forEach((key) => qc.invalidateQueries({ queryKey: key }));
+}
+
+export function useSimulationLeague() {
+  return useQuery<SimulationState | null>({
+    queryKey: ['simulation', 'league'],
+    queryFn: async () => {
+      const res = await axios.get(apiConfig.endpoints.simulator.league, {
+        headers: authHeader(),
+      });
+      return res.data || null;
+    },
+  });
+}
+
+export function useCreateSimulationLeague() {
+  const qc = useQueryClient();
+  return useMutation<SimulationState, Error, CreateSimulationLeagueInput>({
+    mutationFn: async (input) => {
+      const res = await axios.post(apiConfig.endpoints.simulator.leagues, input, {
+        headers: authHeader(),
+      });
+      return res.data;
+    },
+    onSuccess: () => invalidateLeaguePages(qc),
+  });
+}
+
+export function useStartSimulationSeason() {
+  const qc = useQueryClient();
+  return useMutation<SimulationState, Error, string>({
+    mutationFn: async (seasonId) => {
+      const res = await axios.post(
+        apiConfig.endpoints.simulator.start(seasonId),
+        {},
+        { headers: authHeader() },
+      );
+      return res.data;
+    },
+    onSuccess: () => invalidateLeaguePages(qc),
+  });
+}
+
+export function useAdvanceSimulation() {
+  const qc = useQueryClient();
+  return useMutation<
+    AdvanceSimulationResponse,
+    Error,
+    { seasonId: string; rounds?: number; toPlayoffs?: boolean }
+  >({
+    mutationFn: async ({ seasonId, rounds, toPlayoffs }) => {
+      const res = await axios.post(
+        apiConfig.endpoints.simulator.advance(seasonId),
+        { rounds, toPlayoffs },
+        { headers: authHeader() },
+      );
+      return res.data;
+    },
+    onSuccess: () => invalidateLeaguePages(qc),
+  });
+}
+
+export function useSimulationLockedTeams(seasonId: string | null | undefined) {
+  return useQuery<{ teams: SimulationLockedTeam[] }>({
+    queryKey: ['simulation', 'lockedTeams', seasonId],
+    queryFn: async () => {
+      const res = await axios.get(
+        apiConfig.endpoints.simulator.lockedTeams(seasonId!),
+        { headers: authHeader() },
+      );
+      return res.data;
+    },
+    enabled: !!seasonId,
+  });
+}
+
+export function useSetSimulationLockedTeams() {
+  const qc = useQueryClient();
+  return useMutation<void, Error, { seasonId: string; teamIds: number[] }>({
+    mutationFn: async ({ seasonId, teamIds }) => {
+      await axios.put(
+        apiConfig.endpoints.simulator.lockedTeams(seasonId),
+        { teamIds },
+        { headers: authHeader() },
+      );
+    },
+    onSuccess: (_data, { seasonId }) => {
+      qc.invalidateQueries({ queryKey: ['simulation', 'lockedTeams', seasonId] });
+      qc.invalidateQueries({ queryKey: ['lockedTeams'] });
+    },
+  });
+}
+
+export function useDeleteSimulationLeague() {
+  const qc = useQueryClient();
+  return useMutation<{ deleted: true }, Error, number>({
+    mutationFn: async (leagueId) => {
+      const res = await axios.delete(
+        apiConfig.endpoints.simulator.deleteLeague(leagueId),
+        { headers: authHeader() },
+      );
+      return res.data;
+    },
+    onSuccess: () => invalidateLeaguePages(qc),
+  });
+}
+
+export function useRecreateSimulationLeague() {
+  const qc = useQueryClient();
+  return useMutation<SimulationState, Error, number>({
+    mutationFn: async (leagueId) => {
+      const res = await axios.post(
+        apiConfig.endpoints.simulator.recreateLeague(leagueId),
+        {},
+        { headers: authHeader() },
+      );
+      return res.data;
+    },
+    onSuccess: () => invalidateLeaguePages(qc),
+  });
+}

--- a/src/components/FantasyLeaguesSidebar.tsx
+++ b/src/components/FantasyLeaguesSidebar.tsx
@@ -1,6 +1,6 @@
 // FantasyLeaguesSidebar.tsx
 import React from 'react';
-import { Button, Stack, Typography, Divider, Paper } from '@mui/material';
+import { Button, Stack, Typography, Divider, Paper, Chip } from '@mui/material';
 import { FantasyLeague } from '../api/fantasyLeagueQueries';
 import SeasonStatusCard from '../components/SeasonStatusCard';
 import { useFantasyLeagueSeasons } from '../api/useFantasyLeagueSeasons';
@@ -46,6 +46,9 @@ const FantasyLeaguesSidebar: React.FC<Props> = ({
     >
       <Typography variant="h6" gutterBottom>
         {fantasyLeague.name}
+        {fantasyLeague.isSimulation && (
+          <Chip label="Simulação" color="warning" size="small" sx={{ ml: 1 }} />
+        )}
       </Typography>
 
       <Typography variant="body2" sx={{ mb: 1 }}>

--- a/src/components/PlayersList.tsx
+++ b/src/components/PlayersList.tsx
@@ -51,6 +51,7 @@ import Loading from './Loading';
 import { useRealMatchesByRound } from '../api/matchesQueries';
 import { getOpponentForTeam, formatMatchTime } from '../utils/matchUtils';
 import { useLockedTeams } from '../api/fantasyRoundGameQueries';
+import { useSimulationLockedTeams } from '../api/simulatorQueries';
 
 
 const POSITIONS_TRANSLATION = {
@@ -115,8 +116,19 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
     activeRealRound ? seasonYear : undefined,
     activeRealRound ?? undefined,
   );
-  const { data: lockedTeamsData } = useLockedTeams(fantasyLeague.league.externalId, seasonYear, activeRealRound);
-  const lockedTeamIds = new Set<number>(lockedTeamsData?.lockedTeamIds ?? []);
+  // Simulation leagues: locks are the admin's manual per-club toggles, not real kickoffs
+  const isSimulation = !!fantasyLeague.isSimulation;
+  const { data: lockedTeamsData } = useLockedTeams(
+    isSimulation ? undefined : fantasyLeague.league.externalId,
+    seasonYear,
+    activeRealRound,
+  );
+  const { data: simLockedTeams } = useSimulationLockedTeams(isSimulation ? season?.id : null);
+  const lockedTeamIds = new Set<number>(
+    isSimulation
+      ? (simLockedTeams?.teams ?? []).filter((t) => t.locked).map((t) => t.id)
+      : lockedTeamsData?.lockedTeamIds ?? [],
+  );
   const draftCompleted = season ? POST_DRAFT_STATUSES.includes(season.status as LeagueStatus) : false;
 
   const { data: rosterSettingsData } = useRosterSettings(fantasyLeague.id);

--- a/src/components/PlayoffBracket.tsx
+++ b/src/components/PlayoffBracket.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Box, CircularProgress, Paper, Typography } from '@mui/material';
+import { Box, CircularProgress, Paper, Tooltip, Typography } from '@mui/material';
 import { usePlayoffMatchups, FantasyMatchupDto } from '../api/fantasyMatchupQueries';
 
 interface Props {
@@ -149,7 +149,7 @@ function detectByeTeams(
 // ──────────────────────────────────────────────────────────────────────────────
 
 const SLOT_HEIGHT = 84;
-const SLOT_WIDTH = 210;
+const SLOT_WIDTH = 280;
 const CONNECTOR_W = 28;
 
 const scoreStr = (score: number | null) =>
@@ -163,9 +163,10 @@ interface TeamRowProps {
   isTwoLeg: boolean;
   isWinner: boolean;
   hasBorder: boolean;
+  seed?: number | null;
 }
 
-const TeamRow: React.FC<TeamRowProps> = ({ name, score, leg1Score, leg2Score, isTwoLeg, isWinner, hasBorder }) => (
+const TeamRow: React.FC<TeamRowProps> = ({ name, score, leg1Score, leg2Score, isTwoLeg, isWinner, hasBorder, seed }) => (
   <Box
     sx={{
       display: 'flex',
@@ -179,14 +180,27 @@ const TeamRow: React.FC<TeamRowProps> = ({ name, score, leg1Score, leg2Score, is
       minWidth: 0,
     }}
   >
-    <Typography
-      variant="caption"
-      fontWeight={isWinner ? 800 : 400}
-      noWrap
-      sx={{ flex: 1, mr: 0.75, fontSize: 11, lineHeight: 1.3 }}
-    >
-      {name ?? '?'}
-    </Typography>
+    <Box sx={{ display: 'flex', alignItems: 'center', flex: 1, minWidth: 0, mr: 0.75 }}>
+      {seed != null && (
+        <Typography
+          component="span"
+          variant="caption"
+          sx={{ fontSize: 9, color: 'text.disabled', fontWeight: 600, mr: 0.4, flexShrink: 0 }}
+        >
+          #{seed}
+        </Typography>
+      )}
+      <Tooltip title={name ?? ''} placement="top" disableHoverListener={(name?.length ?? 0) <= 20}>
+        <Typography
+          variant="caption"
+          fontWeight={isWinner ? 800 : 400}
+          noWrap
+          sx={{ fontSize: 11, lineHeight: 1.3 }}
+        >
+          {name ?? '?'}
+        </Typography>
+      </Tooltip>
+    </Box>
     {isTwoLeg ? (
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.4, flexShrink: 0 }}>
         <Typography variant="caption" sx={{ fontSize: 10, color: 'text.disabled' }}>
@@ -247,6 +261,7 @@ const MatchupBox: React.FC<{ slot: BracketSlot }> = ({ slot }) => {
         isTwoLeg={isTwoLeg}
         isWinner={homeWon}
         hasBorder
+        seed={rep.homeTeamSeed ?? null}
       />
       <TeamRow
         name={rep.awayTeamName}
@@ -256,23 +271,31 @@ const MatchupBox: React.FC<{ slot: BracketSlot }> = ({ slot }) => {
         isTwoLeg={isTwoLeg}
         isWinner={awayWon}
         hasBorder={false}
+        seed={rep.awayTeamSeed ?? null}
       />
     </Paper>
   );
 };
 
-const ByeBox: React.FC<{ teamName: string }> = ({ teamName }) => (
+const ByeBox: React.FC<{ teamName: string; seed?: number }> = ({ teamName, seed }) => (
   <Paper
     variant="outlined"
     sx={{ width: SLOT_WIDTH, borderRadius: 1.5, overflow: 'hidden', borderColor: 'divider', bgcolor: 'action.hover' }}
   >
-    <Box sx={{ px: 1, py: 0.65, borderBottom: '1px solid', borderColor: 'divider' }}>
-      <Typography variant="caption" fontWeight={700} noWrap sx={{ fontSize: 11 }}>
-        {teamName}
-      </Typography>
+    <Box sx={{ px: 1, py: 0.65, borderBottom: '1px solid', borderColor: 'divider', display: 'flex', alignItems: 'center' }}>
+      {seed != null && (
+        <Typography component="span" variant="caption" sx={{ fontSize: 9, color: 'text.disabled', fontWeight: 600, mr: 0.4, flexShrink: 0 }}>
+          #{seed}
+        </Typography>
+      )}
+      <Tooltip title={teamName} placement="top" disableHoverListener={teamName.length <= 20}>
+        <Typography variant="caption" fontWeight={700} noWrap sx={{ fontSize: 11 }}>
+          {teamName}
+        </Typography>
+      </Tooltip>
     </Box>
     <Box sx={{ px: 1, py: 0.65 }}>
-      <Typography variant="caption" color="text.disabled" sx={{ fontSize: 10 }}>Bye</Typography>
+      <Typography variant="caption" color="text.disabled" sx={{ fontSize: 10 }}>Folga</Typography>
     </Box>
   </Paper>
 );
@@ -344,7 +367,7 @@ const BracketColumn: React.FC<ColumnProps> = ({ maxStage, slotMap, visualOrder, 
               alignItems: 'center',
             }}
           >
-            {byeName ? <ByeBox teamName={byeName} /> : slot ? <MatchupBox slot={slot} /> : <TbdBox />}
+            {byeName ? <ByeBox teamName={byeName} seed={position} /> : slot ? <MatchupBox slot={slot} /> : <TbdBox />}
           </Box>
         );
       })}

--- a/src/components/RodadaTab.tsx
+++ b/src/components/RodadaTab.tsx
@@ -25,17 +25,25 @@ interface Props {
   numberOfRounds?: number | null;
 }
 
+// Returns null when every round (regular + playoffs) is completed — season over
 function detectCurrentRound(
   regularRounds: number[],
   playoffRounds: number[],
   regularSchedule: { roundNumber: number; matchups: FantasyMatchupDto[] }[],
-): number {
+  playoffMatchups: FantasyMatchupDto[],
+): number | null {
   const activeRegular = regularSchedule.find((r) =>
     r.matchups.some((m) => m.status !== 'completed' && m.status !== 'bye'),
   );
   if (activeRegular) return activeRegular.roundNumber;
-  if (playoffRounds.length > 0) return playoffRounds[0];
-  return regularRounds[regularRounds.length - 1];
+  for (const round of playoffRounds) {
+    const matchups = playoffMatchups.filter((m) => m.roundNumber === round);
+    // No matchups yet (bracket/stage not generated) → this round is next up
+    if (matchups.length === 0) return round;
+    if (matchups.some((m) => m.status !== 'completed' && m.status !== 'bye')) return round;
+  }
+  if (playoffRounds.length === 0) return regularRounds[regularRounds.length - 1] ?? null;
+  return null;
 }
 
 // ─── Single matchup row: collapsed = score card, expanded = full detail ──────
@@ -171,9 +179,14 @@ const RodadaTab: React.FC<Props> = ({
   const currentRoundNumber = useMemo(() => {
     if (currentRound != null) return currentRound;
     if (regularRounds.length > 0)
-      return detectCurrentRound(regularRounds, playoffRounds, schedule ?? []);
+      return detectCurrentRound(
+        regularRounds,
+        playoffRounds,
+        schedule ?? [],
+        playoffMatchups ?? [],
+      );
     return null;
-  }, [currentRound, regularRounds, playoffRounds, schedule]);
+  }, [currentRound, regularRounds, playoffRounds, schedule, playoffMatchups]);
 
   if (!seasonId) {
     return (
@@ -199,7 +212,8 @@ const RodadaTab: React.FC<Props> = ({
     );
   }
 
-  const activeRound = selectedRound ?? currentRoundNumber ?? allRounds[0];
+  // Season over (no current round) → default to the last round played
+  const activeRound = selectedRound ?? currentRoundNumber ?? allRounds[allRounds.length - 1];
   const activeIndex = allRounds.indexOf(activeRound);
   const isPlayoffRound = playoffStartRound != null && activeRound >= playoffStartRound;
 

--- a/src/components/ScheduleTab.tsx
+++ b/src/components/ScheduleTab.tsx
@@ -36,20 +36,20 @@ const ScheduleTab: React.FC<Props> = ({ seasonId, userTeamId, seasonYear }) => {
 
   return (
     <Box>
-      <Typography variant="h6" fontWeight={700} mb={2}>
-        Classificação
-      </Typography>
-      <StandingsTable seasonId={seasonId} userTeamId={userTeamId} />
-
       {hasPlayoffMatchups && (
         <>
-          <Divider sx={{ my: 4 }} />
           <Typography variant="h6" fontWeight={700} mb={2}>
             Mata-mata
           </Typography>
           <PlayoffBracket seasonId={seasonId} seasonYear={seasonYear} />
+          <Divider sx={{ my: 4 }} />
         </>
       )}
+
+      <Typography variant="h6" fontWeight={700} mb={2}>
+        Classificação
+      </Typography>
+      <StandingsTable seasonId={seasonId} userTeamId={userTeamId} />
     </Box>
   );
 };

--- a/src/components/ScoringConfigForm.tsx
+++ b/src/components/ScoringConfigForm.tsx
@@ -43,11 +43,11 @@ const ATTACK_ROWS: StatRow[] = [
 
 const DEFENSE_ROWS: StatRow[] = [
   { field: 'penaltySavedPoints', label: 'Defesa de pênalti', note: 'GK / defesa fechada' },
-  { field: 'cleanSheetPoints', label: 'Jogo sem sofrer gols', note: 'GK+DEF / defesa fechada' },
+  { field: 'cleanSheetPoints', label: 'Jogo sem sofrer gols', note: 'GK / defesa fechada' },
   { field: 'savePoints', label: 'Defesa', note: 'GK / defesa fechada' },
   { field: 'tacklePoints', label: 'Desarme' },
   { field: 'ownGoalPoints', label: 'Gol contra' },
-  { field: 'goalConcededPoints', label: 'Gol sofrido', note: 'GK+DEF / defesa fechada' },
+  { field: 'goalConcededPoints', label: 'Gol sofrido', note: 'GK / defesa fechada' },
   { field: 'redCardPoints', label: 'Cartão vermelho' },
   { field: 'yellowCardPoints', label: 'Cartão amarelo' },
   { field: 'foulCommittedPoints', label: 'Falta cometida' },

--- a/src/components/TeamTabComponent.tsx
+++ b/src/components/TeamTabComponent.tsx
@@ -14,7 +14,8 @@ import { UserTeam } from '../api/userTeamsQueries';
 import Loading from './Loading';
 import { useRealMatchesByRound } from '../api/matchesQueries';
 import { getOpponentForTeam } from '../utils/matchUtils';
-import { useLockedTeams } from '../api/fantasyRoundGameQueries';  
+import { useLockedTeams } from '../api/fantasyRoundGameQueries';
+import { useSimulationLockedTeams } from '../api/simulatorQueries';
 import { useFantasyLeagueSeasons } from '../api/useFantasyLeagueSeasons';
 
 interface Props {
@@ -38,8 +39,19 @@ interface Props {
     const { data: season } = useFantasyLeagueSeasons(fantasyLeague.id);
     const currentRealRound = season?.currentRealRound ?? undefined;
     const { data: realMatches } = useRealMatchesByRound(seasonYear, currentRealRound);
-    const { data: lockedTeamsData } = useLockedTeams(fantasyLeague.league.externalId, seasonYear, currentRealRound);
-    const lockedTeamIds = new Set<number>(lockedTeamsData?.lockedTeamIds ?? []);
+    // Simulation leagues: locks are the admin's manual per-club toggles, not real kickoffs
+    const isSimulation = !!fantasyLeague.isSimulation;
+    const { data: lockedTeamsData } = useLockedTeams(
+      isSimulation ? undefined : fantasyLeague.league.externalId,
+      seasonYear,
+      currentRealRound,
+    );
+    const { data: simLockedTeams } = useSimulationLockedTeams(isSimulation ? season?.id : null);
+    const lockedTeamIds = new Set<number>(
+      isSimulation
+        ? (simLockedTeams?.teams ?? []).filter((t) => t.locked).map((t) => t.id)
+        : lockedTeamsData?.lockedTeamIds ?? [],
+    );
     const isViewingOwnTeam = selectedTeamId === userTeam.id;
     const viewedTeam = leagueTeams?.find((t: FantasyLeagueTeamsResponse) => t.id === selectedTeamId);
 

--- a/src/components/UserFantasyLeaguesList.tsx
+++ b/src/components/UserFantasyLeaguesList.tsx
@@ -1,9 +1,10 @@
-import { 
-  Box, 
-  Typography, 
-  Card, 
-  CardActionArea, 
+import {
+  Box,
+  Typography,
+  Card,
+  CardActionArea,
   CardContent,
+  Chip,
 } from '@mui/material';
 import { FantasyLeague } from '../api/fantasyLeagueQueries';
 
@@ -60,6 +61,9 @@ export const UserFantasyLeaguesList = ({ fantasyLeagues, onFantasyLeagueSelect }
               <CardContent>
                 <Typography gutterBottom variant="h6" component="div">
                   {fantasyLeague.name}
+                  {fantasyLeague.isSimulation && (
+                    <Chip label="Simulação" color="warning" size="small" sx={{ ml: 1 }} />
+                  )}
                   {fantasyLeague.isOwner && (
                     <Typography 
                       component="span" 

--- a/src/pages/admin/AdminRoundFlowPage.tsx
+++ b/src/pages/admin/AdminRoundFlowPage.tsx
@@ -40,6 +40,7 @@ import {
 } from '../../api/roundFlowQueries';
 import RoundGamesTab from './RoundGamesTab';
 import SquadSyncTab from './SquadSyncTab';
+import SimulatorTab from './SimulatorTab';
 
 const STATUS_COLORS: Record<RoundFlowStatus, 'default' | 'success' | 'info' | 'warning' | 'secondary' | 'error'> = {
   PENDING: 'default',
@@ -75,10 +76,12 @@ const AdminRoundFlowPage: React.FC = () => {
         <Tab label="Fluxo de Rodada" />
         <Tab label="Jogos da Rodada" />
         <Tab label="Elencos" />
+        <Tab label="Simulador" />
       </Tabs>
       {tab === 0 && <RoundFlowTab />}
       {tab === 1 && <RoundGamesTab />}
       {tab === 2 && <SquadSyncTab />}
+      {tab === 3 && <SimulatorTab />}
     </Box>
   );
 };

--- a/src/pages/admin/SimulatorTab.tsx
+++ b/src/pages/admin/SimulatorTab.tsx
@@ -1,0 +1,619 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Alert,
+  Avatar,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControlLabel,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  MenuItem,
+  Paper,
+  Radio,
+  RadioGroup,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ReplayIcon from '@mui/icons-material/Replay';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import FastForwardIcon from '@mui/icons-material/FastForward';
+import LockIcon from '@mui/icons-material/Lock';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
+import {
+  AdvanceSimulationResponse,
+  SimulationDefenseType,
+  SimulationFillMode,
+  SimulationPlayoffFormat,
+  SimulationState,
+  useAdvanceSimulation,
+  useCreateSimulationLeague,
+  useDeleteSimulationLeague,
+  useRecreateSimulationLeague,
+  useSetSimulationLockedTeams,
+  useSimulationLeague,
+  useSimulationLockedTeams,
+  useStartSimulationSeason,
+} from '../../api/simulatorQueries';
+
+const STATUS_LABELS: Record<string, string> = {
+  INACTIVE: 'Inativa',
+  ACTIVATED_PRESEASON: 'Pré-temporada',
+  DRAFT_SCHEDULED: 'Draft agendado',
+  DRAFT_LIVE: 'Draft ao vivo',
+  DRAFT_DONE: 'Draft concluído',
+  SCHEDULED: 'Tabela gerada',
+  ACTIVE: 'Em andamento',
+  SEASON_ENDED: 'Temporada encerrada',
+  ARCHIVED: 'Arquivada',
+};
+
+const STATUS_COLORS: Record<string, 'default' | 'success' | 'info' | 'warning' | 'secondary'> = {
+  ACTIVATED_PRESEASON: 'info',
+  DRAFT_SCHEDULED: 'warning',
+  DRAFT_LIVE: 'warning',
+  DRAFT_DONE: 'info',
+  SCHEDULED: 'info',
+  ACTIVE: 'success',
+  SEASON_ENDED: 'secondary',
+};
+
+const SimulatorTab: React.FC = () => {
+  const { data: simulation, isLoading } = useSimulationLeague();
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', mt: 6 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return simulation ? <SimulationPanel state={simulation} /> : <CreateSimulationForm />;
+};
+
+// ─── Create form (no simulation exists) ──────────────────────────────────────
+
+const CreateSimulationForm: React.FC = () => {
+  const create = useCreateSimulationLeague();
+  const [name, setName] = useState('Liga de Simulação');
+  const [numberOfTeams, setNumberOfTeams] = useState(8);
+  const [numberOfRounds, setNumberOfRounds] = useState(19);
+  const [fillMode, setFillMode] = useState<SimulationFillMode>('AUTO_FILL');
+  const [defenseType, setDefenseType] = useState<SimulationDefenseType>('CLOSED');
+  const [playoffTeams, setPlayoffTeams] = useState(4);
+  const [playoffFormat, setPlayoffFormat] = useState<SimulationPlayoffFormat>('single_game');
+
+  return (
+    <Paper sx={{ p: 3, maxWidth: 560 }}>
+      <Typography variant="h5" fontWeight="bold" sx={{ mb: 1 }}>
+        Criar Liga de Simulação
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        Cria uma liga sandbox que reproduz o campeonato a partir da rodada 1 usando as
+        estatísticas reais já sincronizadas. Apenas uma simulação pode existir por vez.
+      </Typography>
+
+      <Stack spacing={2}>
+        <TextField
+          label="Nome da liga"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          fullWidth
+        />
+        <TextField
+          select
+          label="Número de times"
+          value={numberOfTeams}
+          onChange={(e) => setNumberOfTeams(Number(e.target.value))}
+        >
+          {[8, 10, 12].map((n) => (
+            <MenuItem key={n} value={n}>{n}</MenuItem>
+          ))}
+        </TextField>
+        <TextField
+          select
+          label="Número de rodadas"
+          value={numberOfRounds}
+          onChange={(e) => setNumberOfRounds(Number(e.target.value))}
+        >
+          {[12, 13, 14, 15, 16, 17, 18, 19].map((n) => (
+            <MenuItem key={n} value={n}>{n}</MenuItem>
+          ))}
+        </TextField>
+        <Stack direction="row" spacing={2}>
+          <TextField
+            select
+            fullWidth
+            label="Times nos playoffs"
+            value={playoffTeams}
+            onChange={(e) => setPlayoffTeams(Number(e.target.value))}
+          >
+            {[4, 6, 7, 8].map((n) => (
+              <MenuItem key={n} value={n}>{n}</MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            select
+            fullWidth
+            label="Formato dos playoffs"
+            value={playoffFormat}
+            onChange={(e) => setPlayoffFormat(e.target.value as SimulationPlayoffFormat)}
+          >
+            <MenuItem value="single_game">Jogo único</MenuItem>
+            <MenuItem value="two_leg_single_game_final">Ida e volta (final única)</MenuItem>
+            <MenuItem value="two_leg_all">Ida e volta (inclusive final)</MenuItem>
+          </TextField>
+        </Stack>
+
+        <Box>
+          <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+            Montagem dos elencos
+          </Typography>
+          <RadioGroup
+            value={fillMode}
+            onChange={(e) => setFillMode(e.target.value as SimulationFillMode)}
+          >
+            <FormControlLabel
+              value="AUTO_FILL"
+              control={<Radio />}
+              label="Preenchimento automático (snake equilibrado por pontuação real)"
+            />
+            <FormControlLabel
+              value="MANUAL_DRAFT"
+              control={<Radio />}
+              label="Draft manual (usar a sala de draft normalmente)"
+            />
+          </RadioGroup>
+        </Box>
+
+        <Box>
+          <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+            Tipo de defesa
+          </Typography>
+          <RadioGroup
+            value={defenseType}
+            onChange={(e) => setDefenseType(e.target.value as SimulationDefenseType)}
+          >
+            <FormControlLabel
+              value="CLOSED"
+              control={<Radio />}
+              label="Fechada (unidade de defesa, ex: Defesa do Flamengo)"
+            />
+            <FormControlLabel
+              value="OPEN"
+              control={<Radio />}
+              label="Aberta (goleiro + defensores individuais)"
+            />
+          </RadioGroup>
+        </Box>
+
+        {create.isError && (
+          <Alert severity="error">
+            {(create.error as any)?.response?.data?.message ?? create.error.message}
+          </Alert>
+        )}
+
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          disabled={create.isPending || !name.trim()}
+          onClick={() =>
+            create.mutate({
+              name: name.trim(),
+              numberOfTeams,
+              numberOfRounds,
+              fillMode,
+              defenseType,
+              playoffTeams,
+              playoffFormat,
+            })
+          }
+        >
+          {create.isPending ? 'Criando…' : 'Criar Simulação'}
+        </Button>
+      </Stack>
+    </Paper>
+  );
+};
+
+// ─── Management panel (simulation exists) ────────────────────────────────────
+
+const SimulationPanel: React.FC<{ state: SimulationState }> = ({ state }) => {
+  const navigate = useNavigate();
+  const start = useStartSimulationSeason();
+  const advance = useAdvanceSimulation();
+  const deleteSim = useDeleteSimulationLeague();
+  const recreate = useRecreateSimulationLeague();
+
+  const [advanceCount, setAdvanceCount] = useState(1);
+  const [advanceResult, setAdvanceResult] = useState<AdvanceSimulationResponse | null>(null);
+  const [locksOpen, setLocksOpen] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [confirmRecreate, setConfirmRecreate] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const canStart = state.status === 'SCHEDULED' || state.status === 'DRAFT_DONE';
+  const canAdvance = state.status === 'ACTIVE';
+  const isEnded = state.status === 'SEASON_ENDED';
+  const inPlayoffs =
+    state.playoffStartRound != null &&
+    state.currentFantasyRound != null &&
+    state.currentFantasyRound >= state.playoffStartRound;
+
+  const errMsg = (err: any) => err?.response?.data?.message ?? err?.message ?? 'Erro';
+
+  const runAdvance = (opts: { rounds?: number; toPlayoffs?: boolean }) => {
+    setActionError(null);
+    advance.mutate(
+      { seasonId: state.seasonId, ...opts },
+      {
+        onSuccess: (data) => setAdvanceResult(data),
+        onError: (err) => setActionError(errMsg(err)),
+      },
+    );
+  };
+
+  return (
+    <Box>
+      <Paper sx={{ p: 3, mb: 3 }}>
+        <Stack direction="row" justifyContent="space-between" alignItems="flex-start" flexWrap="wrap" gap={2}>
+          <Box>
+            <Stack direction="row" alignItems="center" spacing={1}>
+              <Typography variant="h5" fontWeight="bold">{state.leagueName}</Typography>
+              <Chip label="Simulação" color="warning" size="small" />
+              <Chip
+                label={STATUS_LABELS[state.status] ?? state.status}
+                color={STATUS_COLORS[state.status] ?? 'default'}
+                size="small"
+              />
+            </Stack>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+              {state.numberOfTeams} times • {state.numberOfRounds} rodadas • playoffs a partir da
+              rodada {state.playoffStartRound ?? '—'} •{' '}
+              {state.fillMode === 'AUTO_FILL' ? 'preenchimento automático' : 'draft manual'}
+            </Typography>
+            <Typography variant="body2" sx={{ mt: 0.5 }}>
+              {state.currentFantasyRound != null ? (
+                <>
+                  Rodada atual: <b>{state.currentFantasyRound}</b> (rodada real{' '}
+                  <b>{state.currentRealRound ?? '—'}</b>)
+                </>
+              ) : (
+                'Temporada ainda não iniciada'
+              )}
+              {' • '}dados históricos até a rodada real <b>{state.maxAvailableRealRound}</b>
+            </Typography>
+            {isEnded && state.championTeamName && (
+              <Stack direction="row" alignItems="center" spacing={1} sx={{ mt: 1 }}>
+                <EmojiEventsIcon color="warning" />
+                <Typography variant="body1" fontWeight="bold">
+                  Campeão: {state.championTeamName}
+                </Typography>
+              </Stack>
+            )}
+          </Box>
+
+          <Stack spacing={1} alignItems="flex-end">
+            <Button
+              startIcon={<OpenInNewIcon />}
+              onClick={() => navigate(`/fantasy-league/${state.leagueId}`)}
+            >
+              Abrir liga
+            </Button>
+            <Stack direction="row" spacing={1}>
+              <Button
+                size="small"
+                color="warning"
+                startIcon={<ReplayIcon />}
+                onClick={() => setConfirmRecreate(true)}
+              >
+                Recriar
+              </Button>
+              <Button
+                size="small"
+                color="error"
+                startIcon={<DeleteIcon />}
+                onClick={() => setConfirmDelete(true)}
+              >
+                Excluir
+              </Button>
+            </Stack>
+          </Stack>
+        </Stack>
+
+        <Divider sx={{ my: 2 }} />
+
+        <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap" useFlexGap>
+          {canStart && (
+            <Button
+              variant="contained"
+              startIcon={<PlayArrowIcon />}
+              disabled={start.isPending}
+              onClick={() => {
+                setActionError(null);
+                start.mutate(state.seasonId, {
+                  onError: (err) => setActionError(errMsg(err)),
+                });
+              }}
+            >
+              {start.isPending ? 'Iniciando…' : 'Iniciar temporada'}
+            </Button>
+          )}
+
+          {canAdvance && (
+            <>
+              <Button
+                variant="contained"
+                startIcon={<PlayArrowIcon />}
+                disabled={advance.isPending}
+                onClick={() => runAdvance({ rounds: 1 })}
+              >
+                Avançar 1 rodada
+              </Button>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <TextField
+                  size="small"
+                  type="number"
+                  label="N"
+                  value={advanceCount}
+                  onChange={(e) => setAdvanceCount(Math.max(1, Number(e.target.value)))}
+                  sx={{ width: 80 }}
+                />
+                <Button
+                  variant="outlined"
+                  disabled={advance.isPending}
+                  onClick={() => runAdvance({ rounds: advanceCount })}
+                >
+                  Avançar N
+                </Button>
+              </Stack>
+              {!inPlayoffs && (
+                <Button
+                  variant="outlined"
+                  startIcon={<FastForwardIcon />}
+                  disabled={advance.isPending}
+                  onClick={() => runAdvance({ toPlayoffs: true })}
+                >
+                  Avançar até playoffs
+                </Button>
+              )}
+            </>
+          )}
+
+          {(canAdvance || isEnded) && (
+            <Button startIcon={<LockIcon />} onClick={() => setLocksOpen(true)}>
+              Bloqueios de times
+            </Button>
+          )}
+
+          {advance.isPending && <CircularProgress size={22} />}
+        </Stack>
+
+        {state.status === 'ACTIVATED_PRESEASON' && (
+          <Alert severity="info" sx={{ mt: 2 }}>
+            Liga em pré-temporada (draft manual): configure o elenco/draft e conduza a sala de
+            draft pela página da liga. Após o draft a tabela é gerada automaticamente.
+          </Alert>
+        )}
+
+        {actionError && (
+          <Alert severity="error" sx={{ mt: 2 }} onClose={() => setActionError(null)}>
+            {actionError}
+          </Alert>
+        )}
+      </Paper>
+
+      <AdvanceResultDialog result={advanceResult} onClose={() => setAdvanceResult(null)} />
+      <LockedTeamsDialog
+        open={locksOpen}
+        seasonId={state.seasonId}
+        onClose={() => setLocksOpen(false)}
+      />
+
+      <Dialog open={confirmDelete} onClose={() => setConfirmDelete(false)}>
+        <DialogTitle>Excluir simulação?</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Todos os dados da liga "{state.leagueName}" (times, elencos, confrontos, pontuações)
+            serão apagados. Esta ação não pode ser desfeita.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmDelete(false)}>Cancelar</Button>
+          <Button
+            color="error"
+            variant="contained"
+            disabled={deleteSim.isPending}
+            onClick={() =>
+              deleteSim.mutate(state.leagueId, {
+                onSuccess: () => setConfirmDelete(false),
+                onError: (err) => setActionError(errMsg(err)),
+              })
+            }
+          >
+            {deleteSim.isPending ? 'Excluindo…' : 'Excluir'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={confirmRecreate} onClose={() => setConfirmRecreate(false)}>
+        <DialogTitle>Recriar simulação?</DialogTitle>
+        <DialogContent>
+          <Typography>
+            A liga atual será excluída e uma nova será criada com as mesmas configurações
+            (reset completo para a rodada 1).
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmRecreate(false)}>Cancelar</Button>
+          <Button
+            color="warning"
+            variant="contained"
+            disabled={recreate.isPending}
+            onClick={() =>
+              recreate.mutate(state.leagueId, {
+                onSuccess: () => setConfirmRecreate(false),
+                onError: (err) => setActionError(errMsg(err)),
+              })
+            }
+          >
+            {recreate.isPending ? 'Recriando…' : 'Recriar'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};
+
+// ─── Advance result dialog ───────────────────────────────────────────────────
+
+const PLAYOFF_EVENT_LABELS: Record<string, string> = {
+  BRACKET_GENERATED: '🏆 Mata-mata gerado!',
+  ADVANCED: '➡️ Mata-mata avançou de fase',
+  CHAMPION: '👑 Campeão definido!',
+};
+
+const AdvanceResultDialog: React.FC<{
+  result: AdvanceSimulationResponse | null;
+  onClose: () => void;
+}> = ({ result, onClose }) => (
+  <Dialog open={!!result} onClose={onClose} maxWidth="sm" fullWidth>
+    <DialogTitle>Resultado do avanço</DialogTitle>
+    <DialogContent dividers>
+      {result?.error && <Alert severity="warning" sx={{ mb: 2 }}>{result.error}</Alert>}
+      {result?.results.map((round) => (
+        <Box key={round.fantasyRound} sx={{ mb: 2 }}>
+          <Typography variant="subtitle1" fontWeight="bold">
+            Rodada {round.fantasyRound} (real {round.realRound})
+          </Typography>
+          {round.playoffEvent && (
+            <Alert severity={round.playoffEvent === 'CHAMPION' ? 'success' : 'info'} sx={{ my: 1 }}>
+              {PLAYOFF_EVENT_LABELS[round.playoffEvent]}
+            </Alert>
+          )}
+          <List dense disablePadding>
+            {round.matchups
+              .filter((m) => !m.isGhost && m.homeTeamId && m.awayTeamId)
+              .map((m) => (
+                <ListItem key={m.id} disableGutters>
+                  <ListItemText
+                    primary={
+                      <Typography variant="body2">
+                        <b style={{ fontWeight: m.winnerId === m.homeTeamId ? 700 : 400 }}>
+                          {m.homeTeamName}
+                        </b>{' '}
+                        {Number(m.homeScore ?? 0).toFixed(2)} ×{' '}
+                        {Number(m.awayScore ?? 0).toFixed(2)}{' '}
+                        <b style={{ fontWeight: m.winnerId === m.awayTeamId ? 700 : 400 }}>
+                          {m.awayTeamName}
+                        </b>
+                      </Typography>
+                    }
+                  />
+                </ListItem>
+              ))}
+          </List>
+        </Box>
+      ))}
+    </DialogContent>
+    <DialogActions>
+      <Button onClick={onClose}>Fechar</Button>
+    </DialogActions>
+  </Dialog>
+);
+
+// ─── Locked teams dialog ─────────────────────────────────────────────────────
+
+const LockedTeamsDialog: React.FC<{
+  open: boolean;
+  seasonId: string;
+  onClose: () => void;
+}> = ({ open, seasonId, onClose }) => {
+  const { data, isLoading } = useSimulationLockedTeams(open ? seasonId : null);
+  const setLocked = useSetSimulationLockedTeams();
+  const [lockedIds, setLockedIds] = useState<Set<number>>(new Set());
+
+  useEffect(() => {
+    if (data) {
+      setLockedIds(new Set(data.teams.filter((t) => t.locked).map((t) => t.id)));
+    }
+  }, [data]);
+
+  const toggle = (teamId: number) => {
+    setLockedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(teamId)) next.delete(teamId);
+      else next.add(teamId);
+      return next;
+    });
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Bloqueios de times</DialogTitle>
+      <DialogContent dividers>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          Jogadores de times bloqueados não podem ser escalados, trocados ou contratados —
+          simula o bloqueio por partida em andamento.
+        </Typography>
+        {isLoading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', my: 3 }}>
+            <CircularProgress size={28} />
+          </Box>
+        ) : (
+          <List dense>
+            {data?.teams.map((team) => (
+              <ListItem
+                key={team.id}
+                secondaryAction={
+                  <Switch
+                    edge="end"
+                    checked={lockedIds.has(team.id)}
+                    onChange={() => toggle(team.id)}
+                  />
+                }
+              >
+                <ListItemAvatar>
+                  <Avatar src={team.logoUrl ?? undefined} sx={{ width: 28, height: 28 }} />
+                </ListItemAvatar>
+                <ListItemText primary={team.name} />
+              </ListItem>
+            ))}
+          </List>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancelar</Button>
+        <Button
+          variant="contained"
+          disabled={setLocked.isPending}
+          onClick={() =>
+            setLocked.mutate(
+              { seasonId, teamIds: Array.from(lockedIds) },
+              { onSuccess: onClose },
+            )
+          }
+        >
+          {setLocked.isPending ? 'Salvando…' : 'Salvar'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default SimulatorTab;


### PR DESCRIPTION
Add the Simulador admin tab (create form + management panel: start, advance 1/N/to-playoffs, per-club locks, recreate, delete) with its React Query hooks, plus a Simulacao chip on sim leagues.

Bracket polish: show each team's true seed (#N) carried across the whole bracket, wider slots, tooltips for long names, "Bye" -> "Folga", and move the Mata-mata bracket above Classificacao once playoffs start. RodadaTab no longer shows an "Atual" chip after the season ends.