### PR TITLE
feat(users): add user management UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,11 @@ import RequireAdmin from './components/RequireAdmin';
 import Navbar from './components/Navbar';
 import SignIn from './pages/SignIn';
 import SignUp from './pages/SignUp';
+import ForgotPassword from './pages/ForgotPassword';
+import ResetPassword from './pages/ResetPassword';
+import VerifyEmail from './pages/VerifyEmail';
 import Welcome from './pages/Welcome';
+import Profile from './pages/Profile';
 import FantasyLeague from './pages/FantasyLeague';
 import AcceptInvite from './pages/AcceptInvite';
 import DraftRoomPage from './pages/DraftRoomPage';
@@ -24,12 +28,15 @@ const AppRoutes: React.FC = () => {
           <Route element={<PublicRoute />}>
             <Route path="/signin" element={<SignIn />} />
             <Route path="/signup" element={<SignUp />} />
+            <Route path="/forgot-password" element={<ForgotPassword />} />
+            <Route path="/reset-password" element={<ResetPassword />} />
             <Route path="/invite/accept" element={<AcceptInvite />} />
           </Route>
 
           <Route element={<ProtectedLayout />}>
             <Route path="/" element={<div className="App" />} />
             <Route path="/welcome" element={<Welcome />} />
+            <Route path="/profile" element={<Profile />} />
             <Route path="/fantasy-league/:fantasyLeagueId" element={<FantasyLeague currentUserId={currentUserId as number} />} />
             <Route path="/draft/:leagueId/:season/:draftId" element={<DraftRoomPage />} />
           </Route>
@@ -38,6 +45,9 @@ const AppRoutes: React.FC = () => {
             <Route path="/admin" element={<Navigate to="/admin/round-flow" replace />} />
             <Route path="/admin/round-flow" element={<AdminRoundFlowPage />} />
           </Route>
+
+          {/* Accessible whether or not the user is logged in (clicked from email) */}
+          <Route path="/verify-email" element={<VerifyEmail />} />
 
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>

--- a/src/api/authQueries.ts
+++ b/src/api/authQueries.ts
@@ -56,6 +56,76 @@ export const useLogIn = () => {
 };
 
 
+export const useForgotPassword = () => {
+  return useMutation({
+    mutationFn: async (email: string) => {
+      const response = await fetch(apiConfig.endpoints.auth.forgotPassword, {
+        method: 'POST',
+        headers: apiConfig.headers,
+        body: JSON.stringify({ email }),
+      });
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.message || 'Falha ao solicitar redefinição');
+      }
+      return response.json();
+    },
+  });
+};
+
+export const useResetPassword = () => {
+  return useMutation({
+    mutationFn: async (data: { token: string; password: string }) => {
+      const response = await fetch(apiConfig.endpoints.auth.resetPassword, {
+        method: 'POST',
+        headers: apiConfig.headers,
+        body: JSON.stringify(data),
+      });
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.message || 'Falha ao redefinir a senha');
+      }
+      return response.json();
+    },
+  });
+};
+
+export const useVerifyEmail = () => {
+  return useMutation({
+    mutationFn: async (token: string) => {
+      const response = await fetch(apiConfig.endpoints.auth.verifyEmail, {
+        method: 'POST',
+        headers: apiConfig.headers,
+        body: JSON.stringify({ token }),
+      });
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.message || 'Falha ao verificar o email');
+      }
+      return response.json();
+    },
+  });
+};
+
+export const useResendVerification = () => {
+  return useMutation({
+    mutationFn: async () => {
+      const response = await fetch(apiConfig.endpoints.auth.resendVerification, {
+        method: 'POST',
+        headers: {
+          ...apiConfig.headers,
+          Authorization: `Bearer ${localStorage.getItem('token')}`,
+        },
+      });
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.message || 'Falha ao reenviar verificação');
+      }
+      return response.json();
+    },
+  });
+};
+
 export const useGetCurrentUser = () => {
   return useQuery<User>({
     queryKey: ['currentUser'],

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -5,8 +5,13 @@ const endpoints = {
   auth: {
     signup: `${API_BASE_URL}/users/signup`,
     signin: `${API_BASE_URL}/users/signin`,
+    login: `${API_BASE_URL}/auth/login`,
     refresh: `${API_BASE_URL}/auth/refresh`,
     profile: `${API_BASE_URL}/auth/profile`,
+    forgotPassword: `${API_BASE_URL}/auth/forgot-password`,
+    resetPassword: `${API_BASE_URL}/auth/reset-password`,
+    verifyEmail: `${API_BASE_URL}/users/verify-email`,
+    resendVerification: `${API_BASE_URL}/users/me/resend-verification`,
   },
   users: {
     update: `${API_BASE_URL}/users/update`,
@@ -16,6 +21,8 @@ const endpoints = {
     create: `${API_BASE_URL}/fantasy-leagues`,
     get: `${API_BASE_URL}/fantasy-leagues`,
     myLeagues: `${API_BASE_URL}/fantasy-leagues/my-leagues`,
+    join: `${API_BASE_URL}/fantasy-leagues/join`,
+    byCode: (code: string) => `${API_BASE_URL}/fantasy-leagues/by-code/${code}`,
     getLeague: `${API_BASE_URL}/fantasy-leagues`,
     update: (id: number) => `${API_BASE_URL}/fantasy-leagues/${id}`,
     getInvitesByLeagueId: (id: number) => `${API_BASE_URL}/fantasy-leagues/${id}/invites`,

--- a/src/api/fantasyLeagueMutations.ts
+++ b/src/api/fantasyLeagueMutations.ts
@@ -88,6 +88,24 @@ export const useUpdateFantasyLeague = ({ onSuccess }: { onSuccess: () => void })
   });
 };
 
+export const useJoinFantasyLeague = () => {
+  return useMutation({
+    mutationFn: async (joinCode: string) => {
+      const res = await axios.post(
+        apiConfig.endpoints.fantasyLeagues.join,
+        { joinCode },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${localStorage.getItem('token')}`,
+          },
+        },
+      );
+      return res.data as { message: string; leagueId: number };
+    },
+  });
+};
+
 export const useDeleteFantasyLeague = () =>
   useMutation({
     mutationFn: (id: number) =>

--- a/src/api/fantasyLeagueQueries.ts
+++ b/src/api/fantasyLeagueQueries.ts
@@ -17,6 +17,7 @@ export interface FantasyLeague {
     id: number;
     name: string;
     numberOfTeams: number;
+    joinCode?: string | null;
     isOwner?: boolean;
     isActive?: boolean;
     isSimulation?: boolean;

--- a/src/api/userQueries.ts
+++ b/src/api/userQueries.ts
@@ -1,0 +1,45 @@
+import { useMutation } from '@tanstack/react-query';
+import axios from 'axios';
+import { apiConfig } from './config';
+
+const authHeader = () => ({
+  Authorization: `Bearer ${localStorage.getItem('token')}`,
+});
+
+export interface UpdateProfileData {
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  username?: string;
+}
+
+export const useUpdateProfile = () => {
+  return useMutation({
+    mutationFn: async (data: UpdateProfileData) => {
+      const res = await axios.put(
+        `${apiConfig.baseUrl}/users/me`,
+        data,
+        { headers: authHeader() },
+      );
+      return res.data;
+    },
+  });
+};
+
+export interface ChangePasswordData {
+  currentPassword: string;
+  newPassword: string;
+}
+
+export const useChangePassword = () => {
+  return useMutation({
+    mutationFn: async (data: ChangePasswordData) => {
+      const res = await axios.post(
+        `${apiConfig.baseUrl}/users/me/change-password`,
+        data,
+        { headers: authHeader() },
+      );
+      return res.data;
+    },
+  });
+};

--- a/src/components/EmailVerificationBanner.tsx
+++ b/src/components/EmailVerificationBanner.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import { Alert, Button, Snackbar } from '@mui/material';
+import { useAuth } from '../context/AuthContext';
+import { useResendVerification } from '../api/authQueries';
+
+const EmailVerificationBanner: React.FC = () => {
+  const { user } = useAuth();
+  const { mutate: resend, isPending } = useResendVerification();
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  // Only show for logged-in users whose email is not yet verified.
+  if (!user || user.emailVerifiedAt) return null;
+
+  const handleResend = () => {
+    resend(undefined, {
+      onSuccess: () => setFeedback('Email de verificação reenviado.'),
+      onError: (e) =>
+        setFeedback(e instanceof Error ? e.message : 'Falha ao reenviar.'),
+    });
+  };
+
+  return (
+    <>
+      <Alert
+        severity="warning"
+        sx={{ borderRadius: 0 }}
+        action={
+          <Button color="inherit" size="small" onClick={handleResend} disabled={isPending}>
+            Reenviar
+          </Button>
+        }
+      >
+        Seu email ainda não foi verificado. Verifique sua caixa de entrada para
+        receber os convites das ligas.
+      </Alert>
+      <Snackbar
+        open={!!feedback}
+        autoHideDuration={4000}
+        onClose={() => setFeedback(null)}
+        message={feedback}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      />
+    </>
+  );
+};
+
+export default EmailVerificationBanner;

--- a/src/components/FantasyLeaguesSidebar.tsx
+++ b/src/components/FantasyLeaguesSidebar.tsx
@@ -1,10 +1,12 @@
 // FantasyLeaguesSidebar.tsx
-import React from 'react';
-import { Button, Stack, Typography, Divider, Paper, Chip } from '@mui/material';
+import React, { useState } from 'react';
+import { Button, Stack, Typography, Divider, Paper, Chip, Box, Tooltip, IconButton } from '@mui/material';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { FantasyLeague } from '../api/fantasyLeagueQueries';
 import SeasonStatusCard from '../components/SeasonStatusCard';
 import { useFantasyLeagueSeasons } from '../api/useFantasyLeagueSeasons';
 import { useDraftSettings } from '../api/useDraftSettings';
+import { useAuth } from '../context/AuthContext';
 import Loading from './Loading';
 
 type Props = {
@@ -22,7 +24,17 @@ const FantasyLeaguesSidebar: React.FC<Props> = ({
   onViewInvitesClick,
   onSeasonUpdated,
 }) => {
+  const { user } = useAuth();
   const isOwner = currentUserId === fantasyLeague.owner?.id;
+  const isEmailVerified = !!user?.emailVerifiedAt;
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyCode = () => {
+    if (!fantasyLeague.joinCode) return;
+    navigator.clipboard.writeText(fantasyLeague.joinCode);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
 
   const { data: fantasyLeagueSeason,  isLoading: isLoadingFantasyLeagueSeason, refetch: refetchFantasyLeagueSeason } = useFantasyLeagueSeasons(fantasyLeague.id);
   const { data: draftSettings, isLoading: isLoadingDraftSettings } = useDraftSettings(fantasyLeague.id);
@@ -61,16 +73,52 @@ const FantasyLeaguesSidebar: React.FC<Props> = ({
 
       <Divider sx={{ mb: 2 }} />
 
+      {isOwner && fantasyLeague.joinCode && (
+        <Box sx={{ mb: 2 }}>
+          <Typography variant="caption" color="text.secondary">
+            Código de convite
+          </Typography>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              border: '1px solid #e0e0e0',
+              borderRadius: 1,
+              px: 1.5,
+              py: 0.5,
+              mt: 0.5,
+            }}
+          >
+            <Typography sx={{ fontFamily: 'monospace', fontWeight: 700, letterSpacing: 2 }}>
+              {fantasyLeague.joinCode}
+            </Typography>
+            <Tooltip title={copied ? 'Copiado!' : 'Copiar código'}>
+              <IconButton size="small" onClick={handleCopyCode}>
+                <ContentCopyIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        </Box>
+      )}
+
       {isOwner && (
         <Stack spacing={1.5}>
-          <Button
-            fullWidth
-            onClick={onInviteClick}
-            variant="contained"
-            sx={{ borderRadius: 50, textTransform: 'none', fontWeight: 600 }}
+          <Tooltip
+            title={isEmailVerified ? '' : 'Verifique seu email para convidar jogadores'}
           >
-            Convidar para a Liga
-          </Button>
+            <span>
+              <Button
+                fullWidth
+                onClick={onInviteClick}
+                disabled={!isEmailVerified}
+                variant="contained"
+                sx={{ borderRadius: 50, textTransform: 'none', fontWeight: 600 }}
+              >
+                Convidar para a Liga
+              </Button>
+            </span>
+          </Tooltip>
           <Button
             fullWidth
             onClick={onViewInvitesClick}

--- a/src/components/JoinLeagueModal.tsx
+++ b/src/components/JoinLeagueModal.tsx
@@ -1,0 +1,100 @@
+import React, { useState } from 'react';
+import {
+  Modal,
+  Box,
+  Typography,
+  TextField,
+  Button,
+  Alert,
+  CircularProgress,
+} from '@mui/material';
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { useJoinFantasyLeague } from '../api/fantasyLeagueMutations';
+
+interface JoinLeagueModalProps {
+  open: boolean;
+  handleClose: () => void;
+}
+
+const JoinLeagueModal: React.FC<JoinLeagueModalProps> = ({ open, handleClose }) => {
+  const [code, setCode] = useState('');
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { mutate: join, isPending, isError, error, reset } = useJoinFantasyLeague();
+
+  const close = () => {
+    setCode('');
+    reset();
+    handleClose();
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!code.trim()) return;
+    join(code.trim().toUpperCase(), {
+      onSuccess: (data) => {
+        queryClient.invalidateQueries({ queryKey: ['myLeagues'] });
+        close();
+        navigate(`/fantasy-league/${data.leagueId}`);
+      },
+    });
+  };
+
+  return (
+    <Modal open={open} onClose={close}>
+      <Box
+        sx={{
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          width: { xs: '90%', sm: 400 },
+          bgcolor: 'background.paper',
+          borderRadius: 2,
+          boxShadow: 24,
+          p: 4,
+        }}
+      >
+        <Typography variant="h6" sx={{ mb: 1 }}>
+          Entrar com código
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Digite o código de convite que você recebeu do dono da liga.
+        </Typography>
+
+        {isError && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error instanceof Error ? error.message : 'Não foi possível entrar na liga.'}
+          </Alert>
+        )}
+
+        <Box component="form" onSubmit={handleSubmit}>
+          <TextField
+            label="Código"
+            fullWidth
+            value={code}
+            onChange={(e) => setCode(e.target.value.toUpperCase())}
+            inputProps={{ style: { letterSpacing: 4, textTransform: 'uppercase' } }}
+            autoFocus
+          />
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, mt: 3 }}>
+            <Button onClick={close} disabled={isPending}>
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              variant="contained"
+              disabled={isPending || !code.trim()}
+              sx={{ backgroundColor: '#1a1a1a', '&:hover': { backgroundColor: '#333' } }}
+            >
+              {isPending ? <CircularProgress size={22} color="inherit" /> : 'Entrar'}
+            </Button>
+          </Box>
+        </Box>
+      </Box>
+    </Modal>
+  );
+};
+
+export default JoinLeagueModal;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -47,7 +47,12 @@ const Navbar: React.FC = () => {
         {/* Conditional rendering based on auth */}
         {user ? (
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-            <Typography variant="body1" sx={{ fontWeight: 'bold' }}>
+            <Typography
+              variant="body1"
+              component={Link}
+              to="/profile"
+              sx={{ fontWeight: 'bold', color: '#1a1a1a', textDecoration: 'none', '&:hover': { textDecoration: 'underline' } }}
+            >
               Olá, {user.firstName}!
             </Typography>
             {user.isAdmin && (

--- a/src/components/ProtectedLayout.tsx
+++ b/src/components/ProtectedLayout.tsx
@@ -1,6 +1,7 @@
 // ProtectedLayout.tsx
 import { useAuth } from '../context/AuthContext';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import EmailVerificationBanner from './EmailVerificationBanner';
 
 const ProtectedLayout = () => {
   const { user } = useAuth();
@@ -15,7 +16,12 @@ const ProtectedLayout = () => {
     return <Navigate to="/welcome" replace />;
   }
 
-  return <Outlet />;
+  return (
+    <>
+      <EmailVerificationBanner />
+      <Outlet />
+    </>
+  );
 };
 
 export default ProtectedLayout;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -6,13 +6,16 @@ interface User {
   email: string;
   firstName: string;
   lastName: string;
+  username?: string;
   isAdmin?: boolean;
+  emailVerifiedAt?: string | null;
 }
 
 interface AuthContextType {
   user: User | null;
   token: string | null;
   login: (token: string, user: User) => void;
+  updateUser: (partial: Partial<User>) => void;
   logout: () => void;
 }
 
@@ -35,6 +38,15 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     setUser(newUser);
   };
 
+  const updateUser = (partial: Partial<User>) => {
+    setUser((prev) => {
+      if (!prev) return prev;
+      const next = { ...prev, ...partial };
+      localStorage.setItem('user', JSON.stringify(next));
+      return next;
+    });
+  };
+
   const logout = () => {
     localStorage.removeItem('token');
     localStorage.removeItem('user');
@@ -44,7 +56,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   };
 
   return (
-    <AuthContext.Provider value={{ user, token, login, logout }}>
+    <AuthContext.Provider value={{ user, token, login, updateUser, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  TextField,
+  Button,
+  Typography,
+  Link,
+  Alert,
+  CircularProgress,
+} from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+import { useForgotPassword } from '../api/authQueries';
+
+const ForgotPassword: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const { mutate: forgotPassword, isPending, isError, error } = useForgotPassword();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email) return;
+    forgotPassword(email, {
+      onSuccess: () => setSubmitted(true),
+    });
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexGrow: 1,
+          p: 3,
+          maxWidth: 400,
+          mx: 'auto',
+        }}
+      >
+        <Typography variant="h4" component="h1" sx={{ mb: 4, fontWeight: 'bold' }}>
+          Redefinir senha
+        </Typography>
+
+        {submitted ? (
+          <>
+            <Alert severity="success" sx={{ mb: 2, width: '100%' }}>
+              Se o email estiver cadastrado, você receberá instruções para
+              redefinir sua senha.
+            </Alert>
+            <Link component={RouterLink} to="/signin" sx={{ fontWeight: 'bold' }}>
+              Voltar para o login
+            </Link>
+          </>
+        ) : (
+          <>
+            <Typography variant="body1" color="text.secondary" sx={{ mb: 3, textAlign: 'center' }}>
+              Digite seu email e enviaremos um link para criar uma nova senha.
+            </Typography>
+
+            {isError && (
+              <Typography color="error" sx={{ mb: 2 }}>
+                {error instanceof Error ? error.message : 'Algo deu errado.'}
+              </Typography>
+            )}
+
+            <Box component="form" sx={{ width: '100%' }} onSubmit={handleSubmit}>
+              <TextField
+                name="email"
+                label="Email"
+                type="email"
+                variant="outlined"
+                fullWidth
+                margin="normal"
+                placeholder="Digite seu email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+              />
+
+              <Button
+                type="submit"
+                fullWidth
+                variant="contained"
+                disabled={isPending}
+                sx={{
+                  mt: 3,
+                  mb: 2,
+                  py: 1.5,
+                  backgroundColor: '#1a1a1a',
+                  '&:hover': { backgroundColor: '#333' },
+                }}
+              >
+                {isPending ? (
+                  <CircularProgress size={24} color="inherit" />
+                ) : (
+                  'Enviar link'
+                )}
+              </Button>
+            </Box>
+
+            <Typography variant="body1" sx={{ mt: 2 }}>
+              Lembrou da senha?{' '}
+              <Link component={RouterLink} to="/signin" sx={{ fontWeight: 'bold' }}>
+                Entrar
+              </Link>
+            </Typography>
+          </>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default ForgotPassword;

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,212 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Paper,
+  TextField,
+  Button,
+  Typography,
+  Alert,
+  Divider,
+  CircularProgress,
+} from '@mui/material';
+import { useAuth } from '../context/AuthContext';
+import {
+  useUpdateProfile,
+  useChangePassword,
+} from '../api/userQueries';
+
+const Profile: React.FC = () => {
+  const { user, updateUser } = useAuth();
+
+  const [profile, setProfile] = useState({
+    firstName: user?.firstName ?? '',
+    lastName: user?.lastName ?? '',
+    email: user?.email ?? '',
+    username: user?.username ?? '',
+  });
+  const [profileSaved, setProfileSaved] = useState(false);
+
+  const [pwd, setPwd] = useState({ currentPassword: '', newPassword: '', confirm: '' });
+  const [pwdSaved, setPwdSaved] = useState(false);
+  const [pwdLocalError, setPwdLocalError] = useState('');
+
+  const updateProfile = useUpdateProfile();
+  const changePassword = useChangePassword();
+
+  const handleProfileSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setProfileSaved(false);
+    updateProfile.mutate(profile, {
+      onSuccess: (updated) => {
+        updateUser({
+          firstName: updated.firstName,
+          lastName: updated.lastName,
+          email: updated.email,
+          username: updated.username,
+        });
+        setProfileSaved(true);
+      },
+    });
+  };
+
+  const handlePasswordSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setPwdSaved(false);
+    setPwdLocalError('');
+
+    if (pwd.newPassword.length < 8) {
+      setPwdLocalError('A nova senha deve ter no mínimo 8 caracteres.');
+      return;
+    }
+    if (pwd.newPassword !== pwd.confirm) {
+      setPwdLocalError('As senhas não coincidem.');
+      return;
+    }
+
+    changePassword.mutate(
+      { currentPassword: pwd.currentPassword, newPassword: pwd.newPassword },
+      {
+        onSuccess: () => {
+          setPwd({ currentPassword: '', newPassword: '', confirm: '' });
+          setPwdSaved(true);
+        },
+      },
+    );
+  };
+
+  return (
+    <Box sx={{ maxWidth: 600, mx: 'auto', p: { xs: 2, md: 3 } }}>
+      <Typography variant="h4" sx={{ mb: 3, fontWeight: 'bold' }}>
+        Minha conta
+      </Typography>
+
+      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
+        <Typography variant="h6" sx={{ mb: 2 }}>
+          Dados pessoais
+        </Typography>
+
+        {profileSaved && (
+          <Alert severity="success" sx={{ mb: 2 }}>
+            Perfil atualizado com sucesso.
+          </Alert>
+        )}
+        {updateProfile.isError && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {updateProfile.error instanceof Error
+              ? updateProfile.error.message
+              : 'Falha ao atualizar o perfil.'}
+          </Alert>
+        )}
+
+        <Box component="form" onSubmit={handleProfileSubmit}>
+          <TextField
+            label="Nome"
+            fullWidth
+            margin="normal"
+            value={profile.firstName}
+            onChange={(e) => setProfile((p) => ({ ...p, firstName: e.target.value }))}
+          />
+          <TextField
+            label="Sobrenome"
+            fullWidth
+            margin="normal"
+            value={profile.lastName}
+            onChange={(e) => setProfile((p) => ({ ...p, lastName: e.target.value }))}
+          />
+          <TextField
+            label="Nome de usuário"
+            fullWidth
+            margin="normal"
+            value={profile.username}
+            onChange={(e) => setProfile((p) => ({ ...p, username: e.target.value }))}
+          />
+          <TextField
+            label="Email"
+            type="email"
+            fullWidth
+            margin="normal"
+            value={profile.email}
+            onChange={(e) => setProfile((p) => ({ ...p, email: e.target.value }))}
+          />
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={updateProfile.isPending}
+            sx={{ mt: 2, backgroundColor: '#1a1a1a', '&:hover': { backgroundColor: '#333' } }}
+          >
+            {updateProfile.isPending ? (
+              <CircularProgress size={24} color="inherit" />
+            ) : (
+              'Salvar alterações'
+            )}
+          </Button>
+        </Box>
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: 3 }}>
+        <Typography variant="h6" sx={{ mb: 2 }}>
+          Alterar senha
+        </Typography>
+
+        {pwdSaved && (
+          <Alert severity="success" sx={{ mb: 2 }}>
+            Senha alterada com sucesso.
+          </Alert>
+        )}
+        {(changePassword.isError || pwdLocalError) && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {pwdLocalError ||
+              (changePassword.error instanceof Error
+                ? changePassword.error.message
+                : 'Falha ao alterar a senha.')}
+          </Alert>
+        )}
+
+        <Box component="form" onSubmit={handlePasswordSubmit}>
+          <TextField
+            label="Senha atual"
+            type="password"
+            fullWidth
+            margin="normal"
+            value={pwd.currentPassword}
+            onChange={(e) => setPwd((p) => ({ ...p, currentPassword: e.target.value }))}
+            required
+          />
+          <Divider sx={{ my: 1 }} />
+          <TextField
+            label="Nova senha"
+            type="password"
+            fullWidth
+            margin="normal"
+            value={pwd.newPassword}
+            onChange={(e) => setPwd((p) => ({ ...p, newPassword: e.target.value }))}
+            required
+          />
+          <TextField
+            label="Confirmar nova senha"
+            type="password"
+            fullWidth
+            margin="normal"
+            value={pwd.confirm}
+            onChange={(e) => setPwd((p) => ({ ...p, confirm: e.target.value }))}
+            required
+          />
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={changePassword.isPending}
+            sx={{ mt: 2, backgroundColor: '#1a1a1a', '&:hover': { backgroundColor: '#333' } }}
+          >
+            {changePassword.isPending ? (
+              <CircularProgress size={24} color="inherit" />
+            ) : (
+              'Alterar senha'
+            )}
+          </Button>
+        </Box>
+      </Paper>
+    </Box>
+  );
+};
+
+export default Profile;

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  TextField,
+  Button,
+  Typography,
+  Link,
+  Alert,
+  CircularProgress,
+} from '@mui/material';
+import { Link as RouterLink, useNavigate, useSearchParams } from 'react-router-dom';
+import { useResetPassword } from '../api/authQueries';
+
+const ResetPassword: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token') ?? '';
+  const navigate = useNavigate();
+
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [localError, setLocalError] = useState('');
+  const { mutate: resetPassword, isPending, isError, error } = useResetPassword();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setLocalError('');
+
+    if (password.length < 8) {
+      setLocalError('A senha deve ter no mínimo 8 caracteres.');
+      return;
+    }
+    if (password !== confirm) {
+      setLocalError('As senhas não coincidem.');
+      return;
+    }
+
+    resetPassword(
+      { token, password },
+      {
+        onSuccess: () => {
+          navigate('/signin', {
+            state: { message: 'Senha redefinida com sucesso. Faça login.' },
+          });
+        },
+      },
+    );
+  };
+
+  if (!token) {
+    return (
+      <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+        <Box sx={{ flexGrow: 1, p: 3, maxWidth: 400, mx: 'auto', mt: 8 }}>
+          <Alert severity="error" sx={{ mb: 2 }}>
+            Link inválido ou expirado.
+          </Alert>
+          <Link component={RouterLink} to="/forgot-password" sx={{ fontWeight: 'bold' }}>
+            Solicitar um novo link
+          </Link>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexGrow: 1,
+          p: 3,
+          maxWidth: 400,
+          mx: 'auto',
+        }}
+      >
+        <Typography variant="h4" component="h1" sx={{ mb: 4, fontWeight: 'bold' }}>
+          Criar nova senha
+        </Typography>
+
+        {(isError || localError) && (
+          <Typography color="error" sx={{ mb: 2 }}>
+            {localError ||
+              (error instanceof Error ? error.message : 'Algo deu errado.')}
+          </Typography>
+        )}
+
+        <Box component="form" sx={{ width: '100%' }} onSubmit={handleSubmit}>
+          <TextField
+            name="password"
+            label="Nova senha"
+            type="password"
+            variant="outlined"
+            fullWidth
+            margin="normal"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+          <TextField
+            name="confirm"
+            label="Confirmar senha"
+            type="password"
+            variant="outlined"
+            fullWidth
+            margin="normal"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            required
+          />
+
+          <Button
+            type="submit"
+            fullWidth
+            variant="contained"
+            disabled={isPending}
+            sx={{
+              mt: 3,
+              mb: 2,
+              py: 1.5,
+              backgroundColor: '#1a1a1a',
+              '&:hover': { backgroundColor: '#333' },
+            }}
+          >
+            {isPending ? (
+              <CircularProgress size={24} color="inherit" />
+            ) : (
+              'Redefinir senha'
+            )}
+          </Button>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default ResetPassword;

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -10,7 +10,7 @@ import {
 import { Link as RouterLink } from 'react-router-dom';
 import { useLogIn } from '../api/authQueries';
 import { useAuth } from '../context/AuthContext';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import Loading from '../components/Loading';
 
 const SignIn: React.FC = () => {
@@ -26,6 +26,8 @@ const SignIn: React.FC = () => {
 
   const { login } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
+  const successMessage = (location.state as { message?: string })?.message;
   const { mutate: signIn, isPending, isError, error } = useLogIn();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -83,6 +85,12 @@ const SignIn: React.FC = () => {
           Entrar na sua conta
         </Typography>
         
+        {successMessage && (
+          <Typography color="success.main" sx={{ mb: 2 }}>
+            {successMessage}
+          </Typography>
+        )}
+
         {isError && (
           <Typography color="error" sx={{ mb: 2 }}>
             {error instanceof Error ? error.message : 'Falha no login. Verifique suas credenciais.'}
@@ -123,7 +131,13 @@ const SignIn: React.FC = () => {
             helperText={errors.password ? "Senha é obrigatória" : ""}
             required
           />
-          
+
+          <Box sx={{ textAlign: 'right', mt: 1 }}>
+            <Link component={RouterLink} to="/forgot-password" variant="body2">
+              Esqueceu a senha?
+            </Link>
+          </Box>
+
           <Button
             type="submit"
             fullWidth

--- a/src/pages/VerifyEmail.tsx
+++ b/src/pages/VerifyEmail.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useRef } from 'react';
+import { Box, Typography, Alert, Button, CircularProgress } from '@mui/material';
+import { Link as RouterLink, useSearchParams } from 'react-router-dom';
+import { useVerifyEmail } from '../api/authQueries';
+import { useAuth } from '../context/AuthContext';
+
+const VerifyEmail: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token') ?? '';
+  const { user, updateUser } = useAuth();
+  const { mutate: verify, isPending, isError, error, isSuccess } = useVerifyEmail();
+  const attempted = useRef(false);
+
+  useEffect(() => {
+    if (token && !attempted.current) {
+      attempted.current = true;
+      verify(token, {
+        onSuccess: () => {
+          if (user) updateUser({ emailVerifiedAt: new Date().toISOString() });
+        },
+      });
+    }
+  }, [token, verify, user, updateUser]);
+
+  return (
+    <Box sx={{ maxWidth: 480, mx: 'auto', mt: 8, p: 3, textAlign: 'center' }}>
+      <Typography variant="h4" sx={{ mb: 3, fontWeight: 'bold' }}>
+        Verificação de email
+      </Typography>
+
+      {!token && (
+        <Alert severity="error">Link de verificação inválido.</Alert>
+      )}
+
+      {isPending && <CircularProgress />}
+
+      {isSuccess && (
+        <Alert severity="success" sx={{ mb: 2 }}>
+          Seu email foi verificado com sucesso!
+        </Alert>
+      )}
+
+      {isError && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error instanceof Error ? error.message : 'Não foi possível verificar o email.'}
+        </Alert>
+      )}
+
+      {(isSuccess || isError) && (
+        <Button
+          component={RouterLink}
+          to="/welcome"
+          variant="contained"
+          sx={{ mt: 2, backgroundColor: '#1a1a1a', '&:hover': { backgroundColor: '#333' } }}
+        >
+          Ir para o início
+        </Button>
+      )}
+    </Box>
+  );
+};
+
+export default VerifyEmail;

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -4,6 +4,7 @@ import { Box, Typography, Button, Stack, Alert } from '@mui/material';
 import { useAuth } from '../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import CreateLeagueModal from '../components/CreateLeagueModal';
+import JoinLeagueModal from '../components/JoinLeagueModal';
 import { UserFantasyLeaguesList } from '../components/UserFantasyLeaguesList';
 import { useGetMyLeagues } from '../api/fantasyLeagueQueries';
 import { useFantasyLeagueSeasons } from '../api/useFantasyLeagueSeasons';
@@ -15,6 +16,7 @@ const Welcome = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isJoinModalOpen, setIsJoinModalOpen] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   
   // Use the React Query hook
@@ -130,7 +132,7 @@ const acceptInviteMutation = useMutation({
           </Typography>
         ) : (
           <>
-          <Box sx={{ mb: 2 }}>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ mb: 2 }}>
           <Button
             onClick={() => setIsModalOpen(true)}
             sx={{
@@ -145,7 +147,21 @@ const acceptInviteMutation = useMutation({
           >
             Criar Nova Liga
           </Button>
-        </Box>
+          <Button
+            variant="outlined"
+            onClick={() => setIsJoinModalOpen(true)}
+            sx={{
+              padding: '10px 20px',
+              borderRadius: '8px',
+              fontSize: '16px',
+              textTransform: 'none',
+              borderColor: '#1976d2',
+              color: '#1976d2',
+            }}
+          >
+            Entrar com código
+          </Button>
+        </Stack>
           <UserFantasyLeaguesList 
             fantasyLeagues={fantasyLeagues || []} 
             onFantasyLeagueSelect={handleFantasyLeagueSelect} 
@@ -159,6 +175,11 @@ const acceptInviteMutation = useMutation({
         handleClose={() => setIsModalOpen(false)}
         realCurrentRound={firstLeagueSeason?.realCurrentRound ?? null}
         maxRealRound={firstLeagueSeason?.maxRealRound ?? null}
+      />
+
+      <JoinLeagueModal
+        open={isJoinModalOpen}
+        handleClose={() => setIsJoinModalOpen(false)}
       />
 
       {errorMessage && (


### PR DESCRIPTION
Password reset, profile, email verification, and league join-by-code flows wired to the new backend endpoints.

- ForgotPassword / ResetPassword pages + 'Esqueceu a senha?' on SignIn.
- Profile page (edit details + change password); Navbar greeting links to it; AuthContext gains updateUser, username, emailVerifiedAt.
- JoinLeagueModal + 'Entrar com codigo' on Welcome; owner sees the join code with copy in the league sidebar.
- VerifyEmail page + unverified banner with resend in ProtectedLayout; invite button disabled until the owner verifies.