### PR TITLE
refactor(api): centralize query timing constants and league constants

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -1,3 +1,4 @@
+import { STALE_TIME } from './queryConfig';
 
 const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:4000';
 
@@ -195,7 +196,7 @@ const queryConfig = {
     queries: {
       refetchOnWindowFocus: false,
       retry: 1,
-      staleTime: 5 * 60 * 1000,
+      staleTime: STALE_TIME.STANDARD,
     },
   },
 };

--- a/src/api/currentSeasonQueries.ts
+++ b/src/api/currentSeasonQueries.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { apiConfig } from './config';
+import { STALE_TIME } from './queryConfig';
 
 interface CurrentSeason {
   year: number;
@@ -13,6 +14,6 @@ export const useCurrentSeason = () => {
       const res = await axios.get(apiConfig.endpoints.currentSeason);
       return res.data;
     },
-    staleTime: 6 * 60 * 1000, // 10 hour
+    staleTime: STALE_TIME.LONG,
   });
 };

--- a/src/api/draftQueries.ts
+++ b/src/api/draftQueries.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { apiConfig } from './config';
+import { REFETCH_INTERVAL } from './queryConfig';
 
 const authHeader = () => ({ Authorization: `Bearer ${localStorage.getItem('token')}` });
 
@@ -46,7 +47,7 @@ export const useDraftPresence = (draftId: string | undefined) => {
       return res.data;
     },
     enabled: !!draftId,
-    refetchInterval: 5000,
+    refetchInterval: REFETCH_INTERVAL.LIVE,
   });
 };
 
@@ -78,6 +79,6 @@ export const useDraft = (leagueId: number, season: number | undefined) => {
       return res.data ?? null;
     },
     enabled: !!leagueId && !!season,
-    refetchInterval: 30000,
+    refetchInterval: REFETCH_INTERVAL.STANDARD,
   });
 };

--- a/src/api/fantasyLeagueQueries.ts
+++ b/src/api/fantasyLeagueQueries.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { apiConfig } from './config';
+import { STALE_TIME } from './queryConfig';
 import { useQuery } from '@tanstack/react-query';
 import { useMutation } from '@tanstack/react-query';
 import { inviteUserToFantasyLeague } from './fantasyLeagueMutations';
@@ -63,7 +64,7 @@ export interface FantasyLeague {
         );
         return response.data;
       },
-      staleTime: 5 * 60 * 1000,
+      staleTime: STALE_TIME.STANDARD,
     });
   };
 
@@ -82,7 +83,7 @@ export interface FantasyLeague {
         );
         return response.data;
       },
-      staleTime: 5 * 60 * 1000,
+      staleTime: STALE_TIME.STANDARD,
     })
 }
 

--- a/src/api/fantasyRoundGameQueries.ts
+++ b/src/api/fantasyRoundGameQueries.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import { apiConfig } from './config';
+import { STALE_TIME, REFETCH_INTERVAL } from './queryConfig';
 
 const authHeader = () => ({ Authorization: `Bearer ${localStorage.getItem('token')}` });
 
@@ -39,8 +40,8 @@ export const useLockedTeams = (
       return res.data;
     },
     enabled: !!leagueExternalId && !!seasonYear && roundNumber != null,
-    refetchInterval: 2 * 60 * 1000,
-    staleTime: 0,
+    refetchInterval: REFETCH_INTERVAL.SLOW,
+    staleTime: STALE_TIME.ALWAYS,
   });
 
 export const useListRoundMatches = (
@@ -58,7 +59,7 @@ export const useListRoundMatches = (
       return res.data;
     },
     enabled: !!leagueExternalId && !!seasonYear && roundNumber != null,
-    staleTime: 0,
+    staleTime: STALE_TIME.ALWAYS,
   });
 
 // Fetches all rounds in parallel and returns a map of realRound → non-PST match count.
@@ -79,7 +80,7 @@ export const useAllRoundsMatchCounts = (
         return { round, matches: res.data as RoundGameMatch[] };
       },
       enabled: !!leagueExternalId && !!seasonYear,
-      staleTime: 0,
+      staleTime: STALE_TIME.ALWAYS,
     })),
   });
 
@@ -106,7 +107,7 @@ export const useOrphanedMatches = (
       return res.data;
     },
     enabled: !!leagueExternalId && !!seasonYear,
-    staleTime: 0,
+    staleTime: STALE_TIME.ALWAYS,
   });
 
 // ─── Mutations ───────────────────────────────────────────────────────────────
@@ -209,7 +210,7 @@ export const useMatchVenues = (leagueExternalId: number | undefined, seasonYear:
       return res.data;
     },
     enabled: !!leagueExternalId && !!seasonYear,
-    staleTime: 5 * 60 * 1000,
+    staleTime: STALE_TIME.STANDARD,
   });
 
 export const usePatchMatch = () => {

--- a/src/api/matchesQueries.ts
+++ b/src/api/matchesQueries.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { apiConfig } from './config';
+import { STALE_TIME } from './queryConfig';
 
 export interface TeamInfoDto {
   id: number;
@@ -24,7 +25,7 @@ export function useRealMatchesByRound(seasonYear?: number, roundNumber?: number)
         .get(apiConfig.endpoints.matches.byRound(seasonYear!, roundNumber!))
         .then((r) => r.data),
     enabled: !!seasonYear && !!roundNumber,
-    staleTime: Infinity,
+    staleTime: STALE_TIME.STATIC,
     gcTime: 1000 * 60 * 60 * 24,
   });
 }

--- a/src/api/playersQueries.ts
+++ b/src/api/playersQueries.ts
@@ -2,6 +2,7 @@
 import axios from 'axios';
 import { useQuery } from '@tanstack/react-query';
 import { apiConfig } from './config';
+import { STALE_TIME } from './queryConfig';
 
 export interface Player {
   player_id: number;
@@ -101,6 +102,6 @@ export const usePlayersFilters = (params: UsePlayersFiltersParams) => {
       );
       return response.data;
     },
-    staleTime: 5 * 60 * 1000,
+    staleTime: STALE_TIME.STANDARD,
   });
 };

--- a/src/api/queryConfig.ts
+++ b/src/api/queryConfig.ts
@@ -1,0 +1,34 @@
+/**
+ * Centralized React Query timing constants.
+ *
+ * Previously these were scattered as magic numbers (`5 * 60 * 1000`, `30_000`,
+ * `staleTime: 0`, ...) across the `api/*.ts` query hooks. Keeping them here
+ * gives a single place to reason about caching/polling behavior.
+ *
+ * All values are in milliseconds.
+ */
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+
+/** How long fetched data is considered fresh before a refetch can occur. */
+export const STALE_TIME = {
+  /** Always stale — refetch on every mount/observer. For fast-changing data. */
+  ALWAYS: 0,
+  /** Standard cache window for most reads. */
+  STANDARD: 5 * MINUTE,
+  /** Longer window for slowly-changing data (e.g. current season). */
+  LONG: 6 * MINUTE,
+  /** Never goes stale — for effectively-static reference data. */
+  STATIC: Infinity,
+} as const;
+
+/** Background polling intervals for data that changes server-side over time. */
+export const REFETCH_INTERVAL = {
+  /** Fast polling for a live, actively-changing view (e.g. draft board). */
+  LIVE: 5 * SECOND,
+  /** Standard polling for waivers/trades/round-flow status. */
+  STANDARD: 30 * SECOND,
+  /** Slow polling for round games that update infrequently. */
+  SLOW: 2 * MINUTE,
+} as const;

--- a/src/api/roundFlowQueries.ts
+++ b/src/api/roundFlowQueries.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import { apiConfig } from './config';
+import { REFETCH_INTERVAL } from './queryConfig';
 
 const authHeader = () => ({ Authorization: `Bearer ${localStorage.getItem('token')}` });
 
@@ -69,7 +70,7 @@ export function useRoundFlows(filter?: {
       });
       return res.data;
     },
-    refetchInterval: 30_000,
+    refetchInterval: REFETCH_INTERVAL.STANDARD,
   });
 }
 

--- a/src/api/tradeQueries.ts
+++ b/src/api/tradeQueries.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import { apiConfig } from './config';
+import { REFETCH_INTERVAL } from './queryConfig';
 
 const authHeader = () => ({ Authorization: `Bearer ${localStorage.getItem('token')}` });
 
@@ -67,7 +68,7 @@ export function useTrades(seasonId: string | undefined) {
       return res.data;
     },
     enabled: !!seasonId,
-    refetchInterval: 30_000,
+    refetchInterval: REFETCH_INTERVAL.STANDARD,
   });
 }
 

--- a/src/api/waiverQueries.ts
+++ b/src/api/waiverQueries.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import { apiConfig } from './config';
+import { REFETCH_INTERVAL } from './queryConfig';
 
 const authHeader = () => ({ Authorization: `Bearer ${localStorage.getItem('token')}` });
 
@@ -31,7 +32,7 @@ export function useWaiverClaims(seasonId: string | undefined) {
       return res.data;
     },
     enabled: !!seasonId,
-    refetchInterval: 30_000,
+    refetchInterval: REFETCH_INTERVAL.STANDARD,
   });
 }
 
@@ -101,7 +102,7 @@ export function useWaiverWindowStatus(leagueExternalId: number | null | undefine
       return res.data;
     },
     enabled: !!leagueExternalId && !!seasonYear,
-    refetchInterval: 30_000,
+    refetchInterval: REFETCH_INTERVAL.STANDARD,
   });
 }
 

--- a/src/components/CreateLeagueModal.tsx
+++ b/src/components/CreateLeagueModal.tsx
@@ -17,6 +17,11 @@ import {
 } from '@mui/material';
 import { useAuth } from '../context/AuthContext';
 import { useCreateFantasyLeague } from '../api/fantasyLeagueMutations';
+import {
+  CREATION_CUTOFF_ROUND,
+  DEFAULT_ROUNDS,
+  MIN_ROUNDS,
+} from '../constants/league';
 import Loading from './Loading';
 
 const modalStyle = {
@@ -37,10 +42,6 @@ const modalStyle = {
   },
   borderRadius: 3,
 };
-
-const CREATION_CUTOFF_ROUND = 26;
-const DEFAULT_ROUNDS = 19;
-const MIN_ROUNDS = 12;
 
 interface CreateLeagueModalProps {
   open: boolean;

--- a/src/constants/league.ts
+++ b/src/constants/league.ts
@@ -1,0 +1,15 @@
+/**
+ * League creation/season constants shared across the frontend.
+ *
+ * These mirror server-side limits (e.g. the round-26 creation cutoff in
+ * fantasy-leagues.service.ts). Keep them in sync with the backend.
+ */
+
+/** Real championship round after which new leagues can no longer be created. */
+export const CREATION_CUTOFF_ROUND = 26;
+
+/** Default number of fantasy rounds when the calendar allows it. */
+export const DEFAULT_ROUNDS = 19;
+
+/** Minimum number of fantasy rounds a league can be created with. */
+export const MIN_ROUNDS = 12;

--- a/src/pages/AcceptInvite.tsx
+++ b/src/pages/AcceptInvite.tsx
@@ -34,7 +34,6 @@ const InviteAcceptPage = () => {
       return res.json();
     },
     onSuccess: () => {
-      console.log('Invite accepted');
       localStorage.removeItem('league_invite_token');
       // setTimeout(() => navigate('/welcome'), 3000);
     },


### PR DESCRIPTION
- Add api/queryConfig.ts (STALE_TIME / REFETCH_INTERVAL) and replace 18 scattered staleTime/refetchInterval magic numbers across the query hooks.
- Extract CREATION_CUTOFF_ROUND / DEFAULT_ROUNDS / MIN_ROUNDS to constants/league.ts.
- Remove a stray console.log in AcceptInvite.