### PR TITLE
fix(ui): quick-wins batch + PT-BR localization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ const AppRoutes: React.FC = () => {
           <Route element={<ProtectedLayout />}>
             <Route path="/" element={<div className="App" />} />
             <Route path="/welcome" element={<Welcome />} />
+            <Route path="/join" element={<Welcome />} />
             <Route path="/profile" element={<Profile />} />
             <Route path="/fantasy-league/:fantasyLeagueId" element={<FantasyLeague currentUserId={currentUserId as number} />} />
             <Route path="/draft/:leagueId/:season/:draftId" element={<DraftRoomPage />} />

--- a/src/api/fantasyLeagueMutations.ts
+++ b/src/api/fantasyLeagueMutations.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import { apiConfig } from './config';
 
@@ -75,7 +75,8 @@ export const inviteUserToFantasyLeague = async ({
   return res.json();
 };
 
-export const useUpdateFantasyLeague = ({ onSuccess }: { onSuccess: () => void }) => {
+export const useUpdateFantasyLeague = ({ onSuccess }: { onSuccess?: () => void } = {}) => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ id, updates }: UpdateFantasyLeagueData) =>
       axios.patch(`${apiConfig.endpoints.fantasyLeagues.update(id)}`, updates, {
@@ -84,7 +85,12 @@ export const useUpdateFantasyLeague = ({ onSuccess }: { onSuccess: () => void })
           Authorization: `Bearer ${localStorage.getItem('token')}`,
         },
       }),
-    onSuccess: onSuccess,
+    onSuccess: (_data, variables) => {
+      // Refresh the league name app-wide (sidebar, my-leagues list, detail).
+      queryClient.invalidateQueries({ queryKey: ['myLeagues'] });
+      queryClient.invalidateQueries({ queryKey: ['leagueId', variables.id] });
+      onSuccess?.();
+    },
   });
 };
 
@@ -106,8 +112,9 @@ export const useJoinFantasyLeague = () => {
   });
 };
 
-export const useDeleteFantasyLeague = () =>
-  useMutation({
+export const useDeleteFantasyLeague = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
     mutationFn: (id: number) =>
       axios.delete(`${apiConfig.endpoints.fantasyLeagues.delete(id)}`, {
         headers: {
@@ -115,4 +122,10 @@ export const useDeleteFantasyLeague = () =>
           Authorization: `Bearer ${localStorage.getItem('token')}`,
         },
       }),
+    onSuccess: (_data, id) => {
+      // Drop the deleted league from the cached list so it disappears on /welcome.
+      queryClient.invalidateQueries({ queryKey: ['myLeagues'] });
+      queryClient.removeQueries({ queryKey: ['leagueId', id] });
+    },
   });
+};

--- a/src/components/AddPlayerModal.tsx
+++ b/src/components/AddPlayerModal.tsx
@@ -101,7 +101,6 @@ export default function AddPlayerModal({
       <DialogContent dividers>
         <Stack spacing={2}>
           <Stack direction="row" spacing={2} alignItems="center">
-            <Avatar src={player.photo} />
             <div>
               <Typography fontWeight={700}>{player.name}</Typography>
               <Typography variant="body2" color="text.secondary">
@@ -184,7 +183,7 @@ export default function AddPlayerModal({
                         selected={pendingSlot?.index === slot.index}
                       >
                         <ListItemAvatar>
-                          <Avatar src={slot.player!.photo} />
+                          <Avatar />
                         </ListItemAvatar>
                         <ListItemText
                           primary={

--- a/src/components/CreateLeagueModal.tsx
+++ b/src/components/CreateLeagueModal.tsx
@@ -15,6 +15,7 @@ import {
   FormControlLabel,
   Paper,
 } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { useCreateFantasyLeague } from '../api/fantasyLeagueMutations';
 import {
@@ -65,6 +66,7 @@ const draftTypes = [
 
 const CreateLeagueModal: React.FC<CreateLeagueModalProps> = ({ open, handleClose, realCurrentRound, maxRealRound }) => {
   const { user } = useAuth();
+  const navigate = useNavigate();
   const [leagueName, setLeagueName] = useState('');
   const [numberOfTeams, setNumberOfTeams] = useState(8);
   const [draftType, setDraftType] = useState('snake');
@@ -109,7 +111,10 @@ const CreateLeagueModal: React.FC<CreateLeagueModalProps> = ({ open, handleClose
         numberOfRounds,
       },
       {
-        onSuccess: handleClose,
+        onSuccess: (res) => {
+          handleClose();
+          navigate(`/fantasy-league/${res.data.id}`);
+        },
       }
     );
   };

--- a/src/components/DraftOrderDisplay.tsx
+++ b/src/components/DraftOrderDisplay.tsx
@@ -102,7 +102,7 @@ export default function DraftOrderDisplay({ draft, picks, currentUserId, connect
                         <Chip label="Você" size="small" variant="outlined" sx={{ flexShrink: 0 }} />
                       )}
                       {isDone && pick.isAutoDrafted && (
-                        <Chip label="Auto" size="small" color="warning" sx={{ flexShrink: 0 }} />
+                        <Chip label="Automático" size="small" color="warning" sx={{ flexShrink: 0 }} />
                       )}
                     </Paper>
                   );

--- a/src/components/DraftPlayerSearch.tsx
+++ b/src/components/DraftPlayerSearch.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import {
-  Avatar,
   Box,
   Button,
   CircularProgress,
@@ -9,7 +8,6 @@ import {
   InputLabel,
   List,
   ListItem,
-  ListItemAvatar,
   ListItemText,
   MenuItem,
   Pagination,
@@ -157,9 +155,6 @@ export default function DraftPlayerSearch({ leagueId, realLeagueId, realLeagueEx
               </Button>
             }
           >
-            <ListItemAvatar sx={{ minWidth: 40 }}>
-              <Avatar src={player.player_photo} sx={{ width: 32, height: 32 }} />
-            </ListItemAvatar>
             <ListItemText
               primary={
                 <Typography variant="body2" fontWeight={500} noWrap>

--- a/src/components/DraftRoom.tsx
+++ b/src/components/DraftRoom.tsx
@@ -18,6 +18,7 @@ import DraftOrderDisplay from './DraftOrderDisplay';
 import DraftPlayerSearch from './DraftPlayerSearch';
 import DraftMyTeam from './DraftMyTeam';
 import { DraftFullResponse, useFreezeDraft, useResetDraftTimer, useUnfreezeDraft } from '../api/draftQueries';
+import { useAuth } from '../context/AuthContext';
 import { Slot } from './userTeamRosterQueries';
 import { apiConfig } from '../api/config';
 import { mapPositionToSlot } from '../utils/positions';
@@ -89,6 +90,7 @@ export default function DraftRoom({
   }, [currentPickPositionForEffect, isPickerOnlineForEffect]);
   const { mutate: freeze, isPending: isFreezing } = useFreezeDraft();
   const { mutate: unfreeze, isPending: isUnfreezing } = useUnfreezeDraft();
+  const { user } = useAuth();
   const { mutate: resetTimer, isPending: isResetting } = useResetDraftTimer();
 
   const { data: rosterSlots } = useQuery<Slot[]>({
@@ -181,8 +183,8 @@ export default function DraftRoom({
         {!isConnected && (
           <Chip label="Reconectando..." color="error" size="small" />
         )}
-        {/* TEMPORARY — remove after testing */}
-        {draft.status === 'LIVE' && (
+        {/* Draft timer/pause controls — admins only */}
+        {draft.status === 'LIVE' && user?.isAdmin && (
           <Box display="flex" gap={1} ml="auto">
             <Button
               size="small"
@@ -192,7 +194,7 @@ export default function DraftRoom({
               disabled={isResetting}
               sx={{ textTransform: 'none' }}
             >
-              Reset Timer
+              Reiniciar Tempo
             </Button>
             <Button
               size="small"

--- a/src/components/FantasyLeaguesSidebar.tsx
+++ b/src/components/FantasyLeaguesSidebar.tsx
@@ -28,12 +28,24 @@ const FantasyLeaguesSidebar: React.FC<Props> = ({
   const isOwner = currentUserId === fantasyLeague.owner?.id;
   const isEmailVerified = !!user?.emailVerifiedAt;
   const [copied, setCopied] = useState(false);
+  const [copiedLink, setCopiedLink] = useState(false);
 
   const handleCopyCode = () => {
     if (!fantasyLeague.joinCode) return;
     navigator.clipboard.writeText(fantasyLeague.joinCode);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
+  };
+
+  const joinLink = fantasyLeague.joinCode
+    ? `${window.location.origin}/join?code=${fantasyLeague.joinCode}`
+    : '';
+
+  const handleCopyLink = () => {
+    if (!joinLink) return;
+    navigator.clipboard.writeText(joinLink);
+    setCopiedLink(true);
+    setTimeout(() => setCopiedLink(false), 2000);
   };
 
   const { data: fantasyLeagueSeason,  isLoading: isLoadingFantasyLeagueSeason, refetch: refetchFantasyLeagueSeason } = useFantasyLeagueSeasons(fantasyLeague.id);
@@ -99,6 +111,19 @@ const FantasyLeaguesSidebar: React.FC<Props> = ({
               </IconButton>
             </Tooltip>
           </Box>
+
+          <Tooltip title={copiedLink ? 'Link copiado!' : 'Copiar link de convite'}>
+            <Button
+              fullWidth
+              size="small"
+              variant="text"
+              startIcon={<ContentCopyIcon fontSize="small" />}
+              onClick={handleCopyLink}
+              sx={{ mt: 0.5, textTransform: 'none' }}
+            >
+              {copiedLink ? 'Link copiado!' : 'Copiar link de convite'}
+            </Button>
+          </Tooltip>
         </Box>
       )}
 

--- a/src/components/JoinLeagueModal.tsx
+++ b/src/components/JoinLeagueModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Modal,
   Box,
@@ -15,13 +15,19 @@ import { useJoinFantasyLeague } from '../api/fantasyLeagueMutations';
 interface JoinLeagueModalProps {
   open: boolean;
   handleClose: () => void;
+  initialCode?: string;
 }
 
-const JoinLeagueModal: React.FC<JoinLeagueModalProps> = ({ open, handleClose }) => {
-  const [code, setCode] = useState('');
+const JoinLeagueModal: React.FC<JoinLeagueModalProps> = ({ open, handleClose, initialCode }) => {
+  const [code, setCode] = useState(initialCode ?? '');
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { mutate: join, isPending, isError, error, reset } = useJoinFantasyLeague();
+
+  // Prefill the code when opened from a shareable link (?code=…).
+  useEffect(() => {
+    if (open && initialCode) setCode(initialCode);
+  }, [open, initialCode]);
 
   const close = () => {
     setCode('');

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -7,7 +7,7 @@ interface LoadingProps {
   fullScreen?: boolean;
 }
 
-const Loading: React.FC<LoadingProps> = ({ message = 'Loading...', fullScreen = false }) => {
+const Loading: React.FC<LoadingProps> = ({ message = 'Carregando...', fullScreen = false }) => {
   return (
     <Box
       sx={{

--- a/src/components/PlayerSelectModal.tsx
+++ b/src/components/PlayerSelectModal.tsx
@@ -12,7 +12,6 @@ import {
   TableCell,
   TableHead,
   TableRow,
-  Avatar,
   TablePagination,
   IconButton,
   InputAdornment,
@@ -244,10 +243,7 @@ const PlayerSelectModal: React.FC<PlayerSelectModalProps> = ({
                     style={{ cursor: 'pointer' }}
                   >
                     <TableCell>
-                      <Box display="flex" alignItems="center" gap={1}>
-                        <Avatar src={player.player_photo} alt={player.player_name} />
-                        {player.player_name}
-                      </Box>
+                      {player.player_name}
                     </TableCell>
                     <TableCell>{player.team_name}</TableCell>
                     <TableCell>

--- a/src/components/PlayersList.tsx
+++ b/src/components/PlayersList.tsx
@@ -12,7 +12,6 @@ import {
   TableHead,
   TableRow,
   TableSortLabel,
-  Avatar,
   TablePagination,
   useTheme,
   useMediaQuery,
@@ -405,25 +404,10 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
             }}
           >
             <TableCell>
-              <Box display="flex" alignItems="center" gap={1} position="relative">
-                <Box position="relative" display="inline-block">
-                  <Avatar
-                    src={player.player_photo}
-                    alt={player.player_name}
-                  />
-                  {player.is_rostered && (
-                    <LockIcon
-                      fontSize="small"
-                      style={{
-                        position: 'absolute',
-                        right: -4,
-                        bottom: -4,
-                        width: 16,
-                        height: 16,
-                      }}
-                    />
-                  )}
-                </Box>
+              <Box display="flex" alignItems="center" gap={0.5}>
+                {player.is_rostered && (
+                  <LockIcon fontSize="small" sx={{ width: 16, height: 16 }} />
+                )}
                 {player.player_name}
               </Box>
             </TableCell>

--- a/src/components/RosterSettingsForm.tsx
+++ b/src/components/RosterSettingsForm.tsx
@@ -51,6 +51,35 @@ const RosterSettingsForm: React.FC<Props> = ({ values, onChange, id, refetchRost
         </Alert>
       )}
 
+      <Box sx={{ mb: 3 }}>
+        <Typography fontWeight={600} sx={{ mb: 1 }}>Tipo de Defesa</Typography>
+        <ToggleButtonGroup
+          exclusive
+          value={values.defenseType ?? 'CLOSED'}
+          onChange={(_, val) => {
+            if (!val || isLocked) return;
+            onChange('defenseType', val);
+            if (val === 'OPEN') {
+              onChange('starterGkSlots', 1);
+              onChange('starterDefenderSlots', 4);
+            } else {
+              onChange('starterGkSlots', 0);
+              onChange('starterDefenderSlots', 0);
+            }
+          }}
+          disabled={isLocked}
+          size="small"
+        >
+          <ToggleButton value="CLOSED">Defesa Fechada</ToggleButton>
+          <ToggleButton value="OPEN">Defesa Aberta</ToggleButton>
+        </ToggleButtonGroup>
+        <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 0.5 }}>
+          {values.defenseType === 'OPEN'
+            ? 'Jogadores defensores individuais de qualquer time'
+            : 'Unidade defensiva completa de um time (ex: Defesa do Flamengo)'}
+        </Typography>
+      </Box>
+
       {/* Starter Settings */}
       <Typography fontWeight={600} sx={{ mb: 2, fontSize: '1.2rem' }}>Jogadores Titulares</Typography>
       <Box>
@@ -248,35 +277,6 @@ const RosterSettingsForm: React.FC<Props> = ({ values, onChange, id, refetchRost
             onChange={(e) => onChange('maxFwd', e.target.value === '' ? null : Number(e.target.value))}
           />
         </Box>
-      </Box>
-
-      <Box sx={{ mt: 2 }}>
-        <Typography fontWeight={600} sx={{ mb: 1 }}>Tipo de Defesa</Typography>
-        <ToggleButtonGroup
-          exclusive
-          value={values.defenseType ?? 'CLOSED'}
-          onChange={(_, val) => {
-            if (!val || isLocked) return;
-            onChange('defenseType', val);
-            if (val === 'OPEN') {
-              onChange('starterGkSlots', 1);
-              onChange('starterDefenderSlots', 4);
-            } else {
-              onChange('starterGkSlots', 0);
-              onChange('starterDefenderSlots', 0);
-            }
-          }}
-          disabled={isLocked}
-          size="small"
-        >
-          <ToggleButton value="CLOSED">Defesa Fechada</ToggleButton>
-          <ToggleButton value="OPEN">Defesa Aberta</ToggleButton>
-        </ToggleButtonGroup>
-        <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 0.5 }}>
-          {values.defenseType === 'OPEN'
-            ? 'Jogadores defensores individuais de qualquer time'
-            : 'Unidade defensiva completa de um time (ex: Defesa do Flamengo)'}
-        </Typography>
       </Box>
 
       <Box

--- a/src/components/SlotCard.tsx
+++ b/src/components/SlotCard.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Typography, Box, Chip, Paper, Stack, Button } from '@mui/material';
+import { Typography, Box, Chip, Paper, Stack, Button } from '@mui/material';
 import { POSITIONS_TRANSLATION } from '../utils/positions';
 import { RosterPlayer, Slot } from './userTeamRosterQueries';
 import { OpponentInfo, formatMatchTime } from '../utils/matchUtils';
@@ -68,7 +68,6 @@ export enum RosterSlotCard {
           />
           {player ? (
             <>
-              <Avatar src={player.photo} alt={player.name} />
               <Box>
                 <Typography fontWeight="bold" color="text.primary">
                   {player.name}

--- a/src/pages/AcceptInvite.tsx
+++ b/src/pages/AcceptInvite.tsx
@@ -28,7 +28,7 @@ const InviteAcceptPage = () => {
 
       if (!res.ok) {
         const error = await res.json();
-        throw new Error(error.detail || 'Failed to accept invite');
+        throw new Error(error.detail || 'Falha ao aceitar o convite');
       }
 
       return res.json();

--- a/src/pages/DraftRoomPage.tsx
+++ b/src/pages/DraftRoomPage.tsx
@@ -43,6 +43,16 @@ export default function DraftRoomPage() {
 
   const myUserTeam = (teams ?? []).find((t: any) => t.user?.id === currentUser.id);
 
+  // Only league members (users with a team) may enter the draft room.
+  if (teams !== undefined && !myUserTeam) {
+    return (
+      <Box display="flex" flexDirection="column" alignItems="center" pt={10} gap={2}>
+        <Typography variant="h6">Você não participa desta liga.</Typography>
+        <Button onClick={() => navigate('/welcome')}>Voltar</Button>
+      </Box>
+    );
+  }
+
   return (
     <Box sx={{ px: 3, py: 3 }}>
       <Button

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -62,13 +62,13 @@ const SignUp: React.FC = () => {
 
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(errorData.message || 'Registration failed');
+        throw new Error(errorData.message || 'Falha no cadastro');
       }
       return response.json();
     },
     onSuccess: () => {
-      navigate('/signin', { 
-        state: { success: 'Registration successful! Please login.' } 
+      navigate('/signin', {
+        state: { message: 'Cadastro realizado com sucesso! Faça login.' }
       });
     },
   });
@@ -100,8 +100,8 @@ const SignUp: React.FC = () => {
       birthDate: formData.birthDate?.format('YYYY-MM-DD') || '',
     }, {
       onSuccess: () => {
-        navigate('/signin', { 
-          state: { success: 'Registration successful! Please login.' } 
+        navigate('/signin', {
+          state: { message: 'Cadastro realizado com sucesso! Faça login.' }
         });
       }
     });

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from 'react';
 import { Box, Typography, Button, Stack, Alert } from '@mui/material';
 import { useAuth } from '../context/AuthContext';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import CreateLeagueModal from '../components/CreateLeagueModal';
 import JoinLeagueModal from '../components/JoinLeagueModal';
 import { UserFantasyLeaguesList } from '../components/UserFantasyLeaguesList';
@@ -17,6 +17,13 @@ const Welcome = () => {
   const navigate = useNavigate();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isJoinModalOpen, setIsJoinModalOpen] = useState(false);
+  const [searchParams] = useSearchParams();
+  const joinCodeFromLink = searchParams.get('code') ?? undefined;
+
+  // Opened via a shareable invite link (/join?code=…) → open the join modal prefilled.
+  useEffect(() => {
+    if (joinCodeFromLink) setIsJoinModalOpen(true);
+  }, [joinCodeFromLink]);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   
   // Use the React Query hook
@@ -37,7 +44,7 @@ const acceptInviteMutation = useMutation({
 
     if (!res.ok) {
       const error = await res.json();
-      throw new Error(error.detail || 'Failed to accept invite');
+      throw new Error(error.detail || 'Falha ao aceitar o convite');
     }
 
     return res.json();
@@ -180,6 +187,7 @@ const acceptInviteMutation = useMutation({
       <JoinLeagueModal
         open={isJoinModalOpen}
         handleClose={() => setIsJoinModalOpen(false)}
+        initialCode={joinCodeFromLink}
       />
 
       {errorMessage && (


### PR DESCRIPTION
- Redirect to the new league after creation; refresh league list on rename/delete (cache invalidation).
- Shareable join link (/join?code=) prefilling the join modal.
- Move defense-type selector to top of roster settings; remove player images; admin-only draft pause controls; block non-members from draft.
- Translate remaining English UI strings to Portuguese.