### PR TITLE
refactor(league-id): send internal ids to backend; clean admin panel

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -18,6 +18,9 @@ const endpoints = {
     update: `${API_BASE_URL}/users/update`,
     findUserFantasyLeagueTeam: (id: number, fantasyLeagueId: number) => `${API_BASE_URL}/users/${id}/fantasy-leagues/${fantasyLeagueId}`,
   },
+  leagues: {
+    list: `${API_BASE_URL}/leagues`,
+  },
   fantasyLeagues: {
     create: `${API_BASE_URL}/fantasy-leagues`,
     get: `${API_BASE_URL}/fantasy-leagues`,
@@ -92,8 +95,9 @@ const endpoints = {
       `${API_BASE_URL}/fantasy-matchups/season/${seasonId}/unskip/${realRound}`,
   },
   fantasyRoundGames: {
-    lockedTeams: (leagueExternalId: number, seasonYear: number, roundNumber: number) =>
-      `${API_BASE_URL}/fantasy-round-games/league/${leagueExternalId}/season/${seasonYear}/round/${roundNumber}/locked-teams`,
+    // Real-life-global: keyed by the internal real League id (+ season year).
+    lockedTeams: (leagueId: number, seasonYear: number, roundNumber: number) =>
+      `${API_BASE_URL}/fantasy-round-games/league/${leagueId}/season/${seasonYear}/round/${roundNumber}/locked-teams`,
     syncAll: (leagueExternalId: number, seasonYear: number) =>
       `${API_BASE_URL}/fantasy-round-games/league/${leagueExternalId}/season/${seasonYear}/sync-all`,
     syncFromRealRound: (leagueExternalId: number, seasonYear: number, roundNumber: number) =>
@@ -141,7 +145,7 @@ const endpoints = {
     claimsBySeason: (seasonId: string) => `${API_BASE_URL}/waiver/claims/season/${seasonId}`,
     historyBySeason: (seasonId: string) => `${API_BASE_URL}/waiver/claims/season/${seasonId}/history`,
     budgetsBySeason: (seasonId: string) => `${API_BASE_URL}/waiver/budgets/season/${seasonId}`,
-    windowStatus: (leagueExternalId: number, seasonYear: number) => `${API_BASE_URL}/waiver/status/${leagueExternalId}/${seasonYear}`,
+    windowStatus: (leagueId: number, seasonYear: number) => `${API_BASE_URL}/waiver/status/league/${leagueId}/${seasonYear}`,
   },
   roundFlow: {
     list: `${API_BASE_URL}/round-flow`,

--- a/src/api/fantasyRoundGameQueries.ts
+++ b/src/api/fantasyRoundGameQueries.ts
@@ -24,21 +24,22 @@ export interface OrphanedMatch extends RoundGameMatch {
 
 // ─── Queries ────────────────────────────────────────────────────────────────
 
+// Locked teams are real-life-global: keyed by the internal real League id + year.
 export const useLockedTeams = (
-  leagueExternalId: number | undefined,
+  leagueId: number | undefined,
   seasonYear: number | undefined,
   roundNumber: number | null | undefined,
 ) =>
   useQuery<{ lockedTeamIds: number[] }>({
-    queryKey: ['lockedTeams', leagueExternalId, seasonYear, roundNumber],
+    queryKey: ['lockedTeams', leagueId, seasonYear, roundNumber],
     queryFn: async () => {
       const res = await axios.get(
-        apiConfig.endpoints.fantasyRoundGames.lockedTeams(leagueExternalId!, seasonYear!, roundNumber!),
+        apiConfig.endpoints.fantasyRoundGames.lockedTeams(leagueId!, seasonYear!, roundNumber!),
         { headers: authHeader() },
       );
       return res.data;
     },
-    enabled: !!leagueExternalId && !!seasonYear && roundNumber != null,
+    enabled: !!leagueId && !!seasonYear && roundNumber != null,
     refetchInterval: REFETCH_INTERVAL.SLOW,
     staleTime: STALE_TIME.ALWAYS,
   });

--- a/src/api/leaguesQueries.ts
+++ b/src/api/leaguesQueries.ts
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+import { apiConfig } from './config';
+import { authHeader } from './httpClient';
+import { SUPPORTED_LEAGUE } from '../constants/league';
+
+export interface RealLeague {
+  id: number;
+  externalId: number;
+  name: string;
+}
+
+/** Seeded real championships (for admin league pickers). */
+export function useLeagues() {
+  return useQuery<RealLeague[]>({
+    queryKey: ['leagues'],
+    queryFn: async () => {
+      const res = await axios.get(apiConfig.endpoints.leagues.list, {
+        headers: authHeader(),
+      });
+      return res.data;
+    },
+    staleTime: Infinity, // seeded reference data
+  });
+}
+
+/**
+ * The single supported league (Brasileirão Série A) resolved against the
+ * backend so the INTERNAL id is correct regardless of seed order.
+ */
+export function useSupportedLeague() {
+  const { data: leagues, ...rest } = useLeagues();
+  const league = leagues?.find(
+    (l) => l.externalId === SUPPORTED_LEAGUE.externalId,
+  );
+  return { league, ...rest };
+}

--- a/src/api/waiverQueries.ts
+++ b/src/api/waiverQueries.ts
@@ -91,16 +91,17 @@ export function useWaiverHistory(seasonId: string | undefined) {
   });
 }
 
-export function useWaiverWindowStatus(leagueExternalId: number | null | undefined, seasonYear: number | null | undefined) {
+// Waiver windows are real-life-global: keyed by the internal real League id + year.
+export function useWaiverWindowStatus(leagueId: number | null | undefined, seasonYear: number | null | undefined) {
   return useQuery<WaiverWindowStatus>({
-    queryKey: ['waiverWindowStatus', leagueExternalId, seasonYear],
+    queryKey: ['waiverWindowStatus', leagueId, seasonYear],
     queryFn: async () => {
-      const res = await axios.get(apiConfig.endpoints.waiver.windowStatus(leagueExternalId!, seasonYear!), {
+      const res = await axios.get(apiConfig.endpoints.waiver.windowStatus(leagueId!, seasonYear!), {
         headers: authHeader(),
       });
       return res.data;
     },
-    enabled: !!leagueExternalId && !!seasonYear,
+    enabled: !!leagueId && !!seasonYear,
     refetchInterval: REFETCH_INTERVAL.STANDARD,
   });
 }

--- a/src/components/DraftPlayerSearch.tsx
+++ b/src/components/DraftPlayerSearch.tsx
@@ -34,7 +34,6 @@ import { useRosterSettings } from '../api/useRosterSettings';
 interface Props {
   leagueId: number;
   realLeagueId: number | undefined;
-  realLeagueExternalId: number | undefined;
   season: number;
   picks: DraftPick[];
   onPick: (playerId: number) => void;
@@ -42,7 +41,7 @@ interface Props {
   fullPositions?: Set<string>;
 }
 
-export default function DraftPlayerSearch({ leagueId, realLeagueId, realLeagueExternalId, picks, onPick, disabled, fullPositions }: Props) {
+export default function DraftPlayerSearch({ leagueId, realLeagueId, picks, onPick, disabled, fullPositions }: Props) {
   const [search, setSearch] = useState('');
   const [position, setPosition] = useState('ALL');
   const [teamId, setTeamId] = useState<number | ''>('');
@@ -70,7 +69,7 @@ export default function DraftPlayerSearch({ leagueId, realLeagueId, realLeagueEx
   });
 
   const { data: filters } = usePlayersFilters({
-    leagueId: realLeagueExternalId,
+    leagueId: realLeagueId,
   });
 
   const players = data?.data ?? [];

--- a/src/components/DraftRoom.tsx
+++ b/src/components/DraftRoom.tsx
@@ -27,7 +27,6 @@ interface Props {
   draftId: string;
   leagueId: number;
   realLeagueId: number | undefined;
-  realLeagueExternalId: number | undefined;
   season: number;
   currentUserId: number;
   myUserTeamId: number | undefined;
@@ -58,7 +57,6 @@ export default function DraftRoom({
   draftId,
   leagueId,
   realLeagueId,
-  realLeagueExternalId,
   season,
   currentUserId,
   myUserTeamId,
@@ -296,7 +294,6 @@ export default function DraftRoom({
               <DraftPlayerSearch
                 leagueId={leagueId}
                 realLeagueId={realLeagueId}
-                realLeagueExternalId={realLeagueExternalId}
                 season={season}
                 picks={picks}
                 onPick={(playerId) => {

--- a/src/components/PlayerSelectModal.tsx
+++ b/src/components/PlayerSelectModal.tsx
@@ -101,7 +101,7 @@ const PlayerSelectModal: React.FC<PlayerSelectModalProps> = ({
   });
 
   const { data: filtersData } = usePlayersFilters({
-    leagueId: fantasyLeague.league.externalId,
+    leagueId: fantasyLeague.league.id,
     seasonYear,
   });
 

--- a/src/components/PlayersList.tsx
+++ b/src/components/PlayersList.tsx
@@ -88,7 +88,7 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
   // Simulation leagues: locks are the admin's manual per-club toggles, not real kickoffs
   const isSimulation = !!fantasyLeague.isSimulation;
   const { data: lockedTeamsData } = useLockedTeams(
-    isSimulation ? undefined : fantasyLeague.league.externalId,
+    isSimulation ? undefined : fantasyLeague.league.id,
     seasonYear,
     activeRealRound,
   );
@@ -137,8 +137,7 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
   const [waiverClaimOpen, setWaiverClaimOpen] = useState(false);
   const [waiverPlayer, setWaiverPlayer] = useState<null | { id: number; name: string; photo: string; position: string }>(null);
 
-  const leagueExternalId = season?.fantasyLeague?.league?.externalId;
-  const { data: waiverWindowStatus } = useWaiverWindowStatus(leagueExternalId, season?.seasonYear);
+  const { data: waiverWindowStatus } = useWaiverWindowStatus(fantasyLeague.league.id, seasonYear);
   const isWaiverWindowOpen = waiverWindowStatus?.isOpen ?? false;
 
   const { data: waiverBudgets } = useWaiverBudgets(isWaiverWindowOpen ? seasonId : undefined);
@@ -231,7 +230,7 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
   };
 
   const { data: filters, isLoading: loadingFilters } = usePlayersFilters({
-    leagueId: fantasyLeague.league.externalId,
+    leagueId: fantasyLeague.league.id,
     seasonYear,
   });
   

--- a/src/components/TeamTabComponent.tsx
+++ b/src/components/TeamTabComponent.tsx
@@ -42,7 +42,7 @@ interface Props {
     // Simulation leagues: locks are the admin's manual per-club toggles, not real kickoffs
     const isSimulation = !!fantasyLeague.isSimulation;
     const { data: lockedTeamsData } = useLockedTeams(
-      isSimulation ? undefined : fantasyLeague.league.externalId,
+      isSimulation ? undefined : fantasyLeague.league.id,
       seasonYear,
       currentRealRound,
     );

--- a/src/constants/league.ts
+++ b/src/constants/league.ts
@@ -13,3 +13,13 @@ export const DEFAULT_ROUNDS = 19;
 
 /** Minimum number of fantasy rounds a league can be created with. */
 export const MIN_ROUNDS = 12;
+
+/**
+ * The only real championship currently supported. The app is hardcoded to it,
+ * so admin tools display its name rather than asking for an external id.
+ * `externalId` is the api-sports league id (used only at sync/admin boundaries).
+ */
+export const SUPPORTED_LEAGUE = {
+  externalId: 71,
+  name: 'Brasileirão Série A',
+} as const;

--- a/src/pages/DraftRoomPage.tsx
+++ b/src/pages/DraftRoomPage.tsx
@@ -67,7 +67,6 @@ export default function DraftRoomPage() {
         draftId={draftId}
         leagueId={leagueIdNum}
         realLeagueId={fantasyLeague?.league?.id}
-        realLeagueExternalId={fantasyLeague?.league?.externalId}
         season={seasonNum}
         currentUserId={currentUser.id}
         myUserTeamId={myUserTeam?.id}

--- a/src/pages/FantasyLeague.tsx
+++ b/src/pages/FantasyLeague.tsx
@@ -57,10 +57,9 @@ const FantasyLeaguePage = ({ currentUserId }: { currentUserId: number }) => {
   const { data: currentSeasonData } = useCurrentSeason();
   const seasonYear = fantasyLeagueSeason?.seasonYear ?? currentSeasonData?.year ?? new Date().getFullYear();
 
-  const leagueExternalId = fantasyLeagueSeason?.fantasyLeague?.league?.externalId;
   const { data: waiverWindowStatus } = useWaiverWindowStatus(
-    selectedTab === 'players' ? leagueExternalId : null,
-    selectedTab === 'players' ? fantasyLeagueSeason?.seasonYear : null,
+    selectedTab === 'players' ? (fantasyLeague?.league?.id ?? null) : null,
+    selectedTab === 'players' ? seasonYear : null,
   );
   const isWaiverWindowOpen = waiverWindowStatus?.isOpen ?? false;
 

--- a/src/pages/admin/AdminRoundFlowPage.tsx
+++ b/src/pages/admin/AdminRoundFlowPage.tsx
@@ -41,6 +41,7 @@ import {
 import RoundGamesTab from './RoundGamesTab';
 import SquadSyncTab from './SquadSyncTab';
 import SimulatorTab from './SimulatorTab';
+import { useLeagues, useSupportedLeague } from '../../api/leaguesQueries';
 
 const STATUS_COLORS: Record<RoundFlowStatus, 'default' | 'success' | 'info' | 'warning' | 'secondary' | 'error'> = {
   PENDING: 'default',
@@ -88,6 +89,10 @@ const AdminRoundFlowPage: React.FC = () => {
 
 const RoundFlowTab: React.FC = () => {
   const { data: roundFlows = [], isLoading } = useRoundFlows();
+  const { data: leagues = [] } = useLeagues();
+  const leagueNameByExternalId = new Map(
+    leagues.map((l) => [l.externalId, l.name]),
+  );
   const activate = useActivateRoundFlow();
   const update = useUpdateRoundFlow();
   const trigger = useTriggerRoundFlowEvent();
@@ -141,7 +146,7 @@ const RoundFlowTab: React.FC = () => {
               )}
               {roundFlows.map((rf) => (
                 <TableRow key={rf.id} hover>
-                  <TableCell>{rf.leagueExternalId}</TableCell>
+                  <TableCell>{leagueNameByExternalId.get(rf.leagueExternalId) ?? rf.leagueExternalId}</TableCell>
                   <TableCell>{rf.seasonYear}</TableCell>
                   <TableCell>{rf.roundNumber}</TableCell>
                   <TableCell>
@@ -286,14 +291,14 @@ const ActivateRoundDialog: React.FC<{
   isPending: boolean;
   errorMessage?: string;
 }> = ({ open, onClose, onSubmit, isPending, errorMessage }) => {
-  const [leagueExternalId, setLeagueExternalId] = useState('71');
+  const { league } = useSupportedLeague();
   const [seasonYear, setSeasonYear] = useState(String(new Date().getFullYear()));
   const [roundNumber, setRoundNumber] = useState('');
 
   const submit = () => {
-    if (!leagueExternalId || !seasonYear || !roundNumber) return;
+    if (!league || !seasonYear || !roundNumber) return;
     onSubmit({
-      leagueExternalId: Number(leagueExternalId),
+      leagueExternalId: league.externalId,
       seasonYear: Number(seasonYear),
       roundNumber: Number(roundNumber),
     });
@@ -305,11 +310,9 @@ const ActivateRoundDialog: React.FC<{
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
           <TextField
-            label="ID Externo da Liga"
-            type="number"
-            value={leagueExternalId}
-            onChange={(e) => setLeagueExternalId(e.target.value)}
-            helperText="71 = Brasileirão Série A"
+            label="Campeonato"
+            value={league?.name ?? 'Carregando...'}
+            InputProps={{ readOnly: true }}
             fullWidth
           />
           <TextField

--- a/src/pages/admin/RoundGamesTab.tsx
+++ b/src/pages/admin/RoundGamesTab.tsx
@@ -43,6 +43,7 @@ import {
   useSyncAllRounds,
   useSyncRound,
 } from '../../api/fantasyRoundGameQueries';
+import { SUPPORTED_LEAGUE } from '../../constants/league';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -420,11 +421,10 @@ const OrphanedRow: React.FC<{
 const TOTAL_ROUNDS = 38;
 
 const RoundGamesTab: React.FC = () => {
-  const [leagueId, setLeagueId] = useState('71');
   const [seasonYear, setSeasonYear] = useState(String(new Date().getFullYear()));
   const [snack, setSnack] = useState<string | null>(null);
 
-  const leagueExternalId = Number(leagueId) || undefined;
+  const leagueExternalId = SUPPORTED_LEAGUE.externalId;
   const year = Number(seasonYear) || undefined;
 
   const { data: orphaned = [], isLoading: orphanedLoading } = useOrphanedMatches(
@@ -454,13 +454,11 @@ const RoundGamesTab: React.FC = () => {
       {/* Controls */}
       <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 3 }}>
         <TextField
-          label="ID Externo da Liga"
-          type="number"
-          value={leagueId}
-          onChange={(e) => setLeagueId(e.target.value)}
+          label="Campeonato"
+          value={SUPPORTED_LEAGUE.name}
           size="small"
-          sx={{ width: 160 }}
-          helperText="71 = Brasileirão"
+          sx={{ width: 200 }}
+          InputProps={{ readOnly: true }}
         />
         <TextField
           label="Ano da Temporada"

--- a/src/pages/admin/SquadSyncTab.tsx
+++ b/src/pages/admin/SquadSyncTab.tsx
@@ -27,6 +27,7 @@ import axios from 'axios';
 import { apiConfig } from '../../api/config';
 import { authHeader } from '../../api/httpClient';
 import { useSyncAllSquads, useSyncTeamSquad } from '../../api/playerSyncQueries';
+import { useSupportedLeague } from '../../api/leaguesQueries';
 
 interface TeamFilter {
   id: number;
@@ -152,23 +153,25 @@ const TeamRow: React.FC<{
 // ─── Main tab ─────────────────────────────────────────────────────────────────
 
 const SquadSyncTab: React.FC = () => {
-  const [leagueId, setLeagueId] = useState('71');
   const [seasonYear, setSeasonYear] = useState(String(new Date().getFullYear()));
   const [snack, setSnack] = useState<string | null>(null);
 
-  const leagueExternalId = Number(leagueId) || undefined;
+  const { league } = useSupportedLeague();
+  const leagueExternalId = league?.externalId;
+  const leagueInternalId = league?.id;
   const year = Number(seasonYear) || undefined;
 
   const { data: filtersData, isLoading: teamsLoading } = useQuery<{ teams: TeamFilter[] }>({
-    queryKey: ['playerFilters', leagueExternalId, year],
+    queryKey: ['playerFilters', leagueInternalId, year],
     queryFn: async () => {
       const res = await axios.get(apiConfig.endpoints.players.getFilters, {
-        params: { leagueId: leagueExternalId, seasonYear: year },
+        // getFilters is internal-id-keyed; sync calls below use the external id.
+        params: { leagueId: leagueInternalId, seasonYear: year },
         headers: authHeader(),
       });
       return res.data;
     },
-    enabled: !!leagueExternalId && !!year,
+    enabled: !!leagueInternalId && !!year,
     staleTime: 0,
   });
 
@@ -194,13 +197,11 @@ const SquadSyncTab: React.FC = () => {
       {/* Controls */}
       <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 3 }}>
         <TextField
-          label="ID Externo da Liga"
-          type="number"
-          value={leagueId}
-          onChange={(e) => setLeagueId(e.target.value)}
+          label="Campeonato"
+          value={league?.name ?? 'Carregando...'}
           size="small"
-          sx={{ width: 160 }}
-          helperText="71 = Brasileirão"
+          sx={{ width: 200 }}
+          InputProps={{ readOnly: true }}
         />
         <TextField
           label="Ano da Temporada"


### PR DESCRIPTION
- Drop the DraftPlayerSearch two-prop workaround; gameplay components send the internal league id (usePlayersFilters now matches usePlayers).
- Waiver-status + locked-teams hooks key by internal real League id + seasonYear (real-life-global), preserving the simulation disable path.
- Admin panel: remove the hand-typed 'ID Externo da Liga' inputs; show the league name (via useLeagues / SUPPORTED_LEAGUE) in RoundGamesTab, SquadSyncTab and the round-flow activate dialog + table.