### PR TITLE
feat(player-ranking): admin ranking tab + context-aware player sort

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,7 @@ const AppRoutes: React.FC = () => {
 
           <Route element={<RequireAdmin />}>
             <Route path="/admin" element={<Navigate to="/admin/round-flow" replace />} />
-            <Route path="/admin/round-flow" element={<AdminRoundFlowPage />} />
+            <Route path="/admin/:tab" element={<AdminRoundFlowPage />} />
           </Route>
 
           {/* Accessible whether or not the user is logged in (clicked from email) */}

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -21,6 +21,13 @@ const endpoints = {
   leagues: {
     list: `${API_BASE_URL}/leagues`,
   },
+  playerRanking: {
+    list: `${API_BASE_URL}/admin/player-ranking`,
+    config: `${API_BASE_URL}/admin/player-ranking/config`,
+    availability: (playerId: number) => `${API_BASE_URL}/admin/player-ranking/${playerId}/availability`,
+    nudge: (playerId: number) => `${API_BASE_URL}/admin/player-ranking/${playerId}/nudge`,
+    recompute: `${API_BASE_URL}/admin/player-ranking/recompute`,
+  },
   fantasyLeagues: {
     create: `${API_BASE_URL}/fantasy-leagues`,
     get: `${API_BASE_URL}/fantasy-leagues`,

--- a/src/api/playerRankingQueries.ts
+++ b/src/api/playerRankingQueries.ts
@@ -1,0 +1,108 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
+import { apiConfig } from './config';
+import { authHeader } from './httpClient';
+
+export type AvailabilityStatus =
+  | 'HEALTHY'
+  | 'MINOR'
+  | 'MAJOR'
+  | 'LONG_TERM'
+  | 'SEASON_ENDING';
+
+export interface PlayerRankingRow {
+  playerId: number;
+  name: string;
+  position: string;
+  teamName: string | null;
+  draftRank: number | null;
+  autoStatScore: number;
+  finalScore: number;
+  availabilityStatus: AvailabilityStatus;
+  manualNudge: number;
+}
+
+export interface RankingConfig {
+  id: number;
+  healthyMultiplier: number;
+  minorMultiplier: number;
+  majorMultiplier: number;
+  longTermMultiplier: number;
+  seasonEndingMultiplier: number;
+}
+
+export function usePlayerRankings() {
+  return useQuery<PlayerRankingRow[]>({
+    queryKey: ['playerRankings'],
+    queryFn: async () => {
+      const res = await axios.get(apiConfig.endpoints.playerRanking.list, {
+        headers: authHeader(),
+      });
+      return res.data;
+    },
+  });
+}
+
+export function useRankingConfig() {
+  return useQuery<RankingConfig>({
+    queryKey: ['rankingConfig'],
+    queryFn: async () => {
+      const res = await axios.get(apiConfig.endpoints.playerRanking.config, {
+        headers: authHeader(),
+      });
+      return res.data;
+    },
+  });
+}
+
+function useRankingMutation<TVars>(
+  fn: (vars: TVars) => Promise<unknown>,
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: fn,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['playerRankings'] });
+      queryClient.invalidateQueries({ queryKey: ['rankingConfig'] });
+      queryClient.invalidateQueries({ queryKey: ['players'] });
+    },
+  });
+}
+
+export function useSetAvailability() {
+  return useRankingMutation<{ playerId: number; status: AvailabilityStatus }>(
+    ({ playerId, status }) =>
+      axios.patch(
+        apiConfig.endpoints.playerRanking.availability(playerId),
+        { status },
+        { headers: authHeader() },
+      ),
+  );
+}
+
+export function useSetNudge() {
+  return useRankingMutation<{ playerId: number; nudge: number }>(
+    ({ playerId, nudge }) =>
+      axios.patch(
+        apiConfig.endpoints.playerRanking.nudge(playerId),
+        { nudge },
+        { headers: authHeader() },
+      ),
+  );
+}
+
+export function useUpdateRankingConfig() {
+  return useRankingMutation<Partial<RankingConfig>>((dto) =>
+    axios.patch(apiConfig.endpoints.playerRanking.config, dto, {
+      headers: authHeader(),
+    }),
+  );
+}
+
+export function useRecomputeRankings() {
+  return useRankingMutation<void>(() =>
+    axios.post(apiConfig.endpoints.playerRanking.recompute, {}, {
+      headers: authHeader(),
+    }),
+  );
+}

--- a/src/components/DraftPlayerSearch.tsx
+++ b/src/components/DraftPlayerSearch.tsx
@@ -60,7 +60,7 @@ export default function DraftPlayerSearch({ leagueId, realLeagueId, picks, onPic
     teamId: teamId || undefined,
     page,
     limit: 20,
-    sortBy: 'name',
+    sortBy: 'draftRank',
     order: 'asc',
     leagueId: realLeagueId,
     fantasyLeagueId: leagueId,

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -58,7 +58,7 @@ const Navbar: React.FC = () => {
             {user.isAdmin && (
               <Button
                 component={Link}
-                to="/admin/round-flow"
+                to="/admin"
                 variant="text"
                 sx={{ textTransform: 'none', fontWeight: 'bold', color: '#1a1a1a' }}
               >

--- a/src/components/PlayersList.tsx
+++ b/src/components/PlayersList.tsx
@@ -112,7 +112,9 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const [onlyFreeAgents, setOnlyFreeAgents] = useState(false);
   const [teamId, setTeamId] = useState<number | null>(null);
-  const [sortBy, setSortBy] = useState<string>('totalPoints');
+  // 'auto' = let the backend pick: per-league points once the season has points,
+  // global draft ranking pre-season. Explicit column clicks override it.
+  const [sortBy, setSortBy] = useState<string>('auto');
   const [order, setOrder] = useState<'asc' | 'desc'>('desc');
 
   const handleSort = (col: string) => {
@@ -208,6 +210,10 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
     onlyFreeAgents,
   });
 
+
+  // When sortBy is 'auto', the backend resolves the real column (totalPoints or
+  // draftRank). Use the resolved value from meta so the right header highlights.
+  const activeSort = sortBy === 'auto' ? data?.meta?.sortBy ?? '' : sortBy;
 
   const previousDataRef = useRef<any[]>([]);
   useEffect(() => {
@@ -348,8 +354,8 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
         {currentRound && <TableCell>Próx.</TableCell>}
         <TableCell align="right">
           <TableSortLabel
-            active={sortBy === 'goals'}
-            direction={sortBy === 'goals' ? order : 'desc'}
+            active={activeSort === 'goals'}
+            direction={activeSort === 'goals' ? order : 'desc'}
             onClick={() => handleSort('goals')}
           >
             Gols
@@ -357,8 +363,8 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
         </TableCell>
         <TableCell align="right">
           <TableSortLabel
-            active={sortBy === 'totalPoints'}
-            direction={sortBy === 'totalPoints' ? order : 'desc'}
+            active={activeSort === 'totalPoints'}
+            direction={activeSort === 'totalPoints' ? order : 'desc'}
             onClick={() => handleSort('totalPoints')}
           >
             Pts Total
@@ -366,8 +372,8 @@ const PlayersList: React.FC<PlayersListProps> = ({ fantasyLeague, seasonYear, us
         </TableCell>
         <TableCell align="right">
           <TableSortLabel
-            active={sortBy === 'avgPoints'}
-            direction={sortBy === 'avgPoints' ? order : 'desc'}
+            active={activeSort === 'avgPoints'}
+            direction={activeSort === 'avgPoints' ? order : 'desc'}
             onClick={() => handleSort('avgPoints')}
           >
             Média

--- a/src/pages/admin/AdminRoundFlowPage.tsx
+++ b/src/pages/admin/AdminRoundFlowPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
 import {
   Box,
   Button,
@@ -41,6 +42,7 @@ import {
 import RoundGamesTab from './RoundGamesTab';
 import SquadSyncTab from './SquadSyncTab';
 import SimulatorTab from './SimulatorTab';
+import PlayerRankingTab from './PlayerRankingTab';
 import { useLeagues, useSupportedLeague } from '../../api/leaguesQueries';
 
 const STATUS_COLORS: Record<RoundFlowStatus, 'default' | 'success' | 'info' | 'warning' | 'secondary' | 'error'> = {
@@ -65,24 +67,42 @@ function toLocalInput(iso: string): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
+// URL slug ↔ tab. Each admin tab is deep-linkable at /admin/<slug>.
+const ADMIN_TABS = [
+  { slug: 'round-flow', label: 'Fluxo de Rodada', render: () => <RoundFlowTab /> },
+  { slug: 'round-games', label: 'Jogos da Rodada', render: () => <RoundGamesTab /> },
+  { slug: 'squads', label: 'Elencos', render: () => <SquadSyncTab /> },
+  { slug: 'simulator', label: 'Simulador', render: () => <SimulatorTab /> },
+  { slug: 'ranking', label: 'Ranking de Jogadores', render: () => <PlayerRankingTab /> },
+] as const;
+
+const DEFAULT_TAB = ADMIN_TABS[0].slug;
+
 const AdminRoundFlowPage: React.FC = () => {
-  const [tab, setTab] = useState(0);
+  const { tab: tabSlug } = useParams<{ tab: string }>();
+  const navigate = useNavigate();
+
+  const index = ADMIN_TABS.findIndex((t) => t.slug === tabSlug);
+  // Unknown / missing slug → redirect to the default tab.
+  if (index === -1) {
+    return <Navigate to={`/admin/${DEFAULT_TAB}`} replace />;
+  }
 
   return (
     <Box sx={{ p: 3, maxWidth: 1400, mx: 'auto' }}>
       <Typography variant="h4" fontWeight="bold" sx={{ mb: 2 }}>
         Painel Admin
       </Typography>
-      <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 3, borderBottom: 1, borderColor: 'divider' }}>
-        <Tab label="Fluxo de Rodada" />
-        <Tab label="Jogos da Rodada" />
-        <Tab label="Elencos" />
-        <Tab label="Simulador" />
+      <Tabs
+        value={index}
+        onChange={(_, v) => navigate(`/admin/${ADMIN_TABS[v].slug}`)}
+        sx={{ mb: 3, borderBottom: 1, borderColor: 'divider' }}
+      >
+        {ADMIN_TABS.map((t) => (
+          <Tab key={t.slug} label={t.label} />
+        ))}
       </Tabs>
-      {tab === 0 && <RoundFlowTab />}
-      {tab === 1 && <RoundGamesTab />}
-      {tab === 2 && <SquadSyncTab />}
-      {tab === 3 && <SimulatorTab />}
+      {ADMIN_TABS[index].render()}
     </Box>
   );
 };

--- a/src/pages/admin/PlayerRankingTab.tsx
+++ b/src/pages/admin/PlayerRankingTab.tsx
@@ -1,0 +1,372 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  MenuItem,
+  Pagination,
+  Paper,
+  Select,
+  Snackbar,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import SyncIcon from '@mui/icons-material/Sync';
+import {
+  AvailabilityStatus,
+  usePlayerRankings,
+  useRankingConfig,
+  useRecomputeRankings,
+  useSetAvailability,
+  useSetNudge,
+  useUpdateRankingConfig,
+} from '../../api/playerRankingQueries';
+
+const STATUS_LABELS: Record<AvailabilityStatus, string> = {
+  HEALTHY: 'Disponível',
+  MINOR: 'Lesão leve',
+  MAJOR: 'Lesão (semanas)',
+  LONG_TERM: 'Lesão longa',
+  SEASON_ENDING: 'Fora da temporada',
+};
+
+const MULTIPLIER_FIELDS: { key: keyof MultConfig; label: string }[] = [
+  { key: 'healthyMultiplier', label: 'Disponível' },
+  { key: 'minorMultiplier', label: 'Lesão leve' },
+  { key: 'majorMultiplier', label: 'Lesão (semanas)' },
+  { key: 'longTermMultiplier', label: 'Lesão longa' },
+  { key: 'seasonEndingMultiplier', label: 'Fora da temporada' },
+];
+
+type MultConfig = {
+  healthyMultiplier: number;
+  minorMultiplier: number;
+  majorMultiplier: number;
+  longTermMultiplier: number;
+  seasonEndingMultiplier: number;
+};
+
+/**
+ * Controlled numeric input that only fires onCommit when the value actually
+ * changes, on blur or Enter. Remounted (via key) on the parent's refetch so it
+ * always reflects the persisted server value.
+ */
+const NudgeField: React.FC<{
+  value: number;
+  onCommit: (value: number) => void;
+}> = ({ value, onCommit }) => {
+  const [local, setLocal] = useState(String(value));
+  const commit = () => {
+    const n = Number(local);
+    if (!Number.isNaN(n) && n !== value) onCommit(n);
+  };
+  return (
+    <TextField
+      type="number"
+      size="small"
+      value={local}
+      sx={{ width: 90 }}
+      onChange={(e) => setLocal(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+      }}
+    />
+  );
+};
+
+const PlayerRankingTab: React.FC = () => {
+  const { data: rankings = [], isLoading } = usePlayerRankings();
+  const { data: config } = useRankingConfig();
+  const recompute = useRecomputeRankings();
+  const setAvailability = useSetAvailability();
+  const setNudge = useSetNudge();
+  const updateConfig = useUpdateRankingConfig();
+  const [snack, setSnack] = useState<string | null>(null);
+  const [draftConfig, setDraftConfig] = useState<Partial<MultConfig>>({});
+  const [search, setSearch] = useState('');
+  const [availabilityFilter, setAvailabilityFilter] = useState<'ALL' | AvailabilityStatus>('ALL');
+  const [teamFilter, setTeamFilter] = useState('ALL');
+  const [positionFilter, setPositionFilter] = useState('ALL');
+  const [page, setPage] = useState(1);
+
+  const teamOptions = Array.from(
+    new Set(rankings.map((r) => r.teamName).filter((t): t is string => !!t)),
+  ).sort((a, b) => a.localeCompare(b));
+  const positionOptions = Array.from(
+    new Set(rankings.map((r) => r.position).filter(Boolean)),
+  ).sort((a, b) => a.localeCompare(b));
+
+  const PAGE_SIZE = 25;
+  const term = search.trim().toLowerCase();
+  const filtered = rankings.filter(
+    (r) =>
+      (!term || r.name.toLowerCase().includes(term)) &&
+      (availabilityFilter === 'ALL' || r.availabilityStatus === availabilityFilter) &&
+      (teamFilter === 'ALL' || r.teamName === teamFilter) &&
+      (positionFilter === 'ALL' || r.position === positionFilter),
+  );
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages);
+  const pageRows = filtered.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
+
+  const handleRecompute = () =>
+    recompute.mutate(undefined, {
+      onSuccess: () => setSnack('Ranking recalculado.'),
+      onError: (e) => setSnack(`Erro: ${(e as Error).message}`),
+    });
+
+  const handleSaveConfig = () =>
+    updateConfig.mutate(draftConfig, {
+      onSuccess: () => {
+        setSnack('Multiplicadores atualizados e ranking recalculado.');
+        setDraftConfig({});
+      },
+      onError: (e) => setSnack(`Erro: ${(e as Error).message}`),
+    });
+
+  return (
+    <Box>
+      <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 2 }}>
+        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+          Ranking de Jogadores
+        </Typography>
+        <Button
+          variant="contained"
+          startIcon={
+            recompute.isPending ? (
+              <CircularProgress size={16} color="inherit" />
+            ) : (
+              <SyncIcon />
+            )
+          }
+          disabled={recompute.isPending}
+          onClick={handleRecompute}
+        >
+          Recalcular
+        </Button>
+      </Stack>
+
+      {/* Availability multipliers */}
+      <Paper variant="outlined" sx={{ p: 2, mb: 3 }}>
+        <Typography variant="subtitle2" sx={{ mb: 1 }}>
+          Multiplicadores de disponibilidade
+        </Typography>
+        <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap" useFlexGap>
+          {MULTIPLIER_FIELDS.map(({ key, label }) => (
+            <TextField
+              key={key}
+              label={label}
+              type="number"
+              size="small"
+              sx={{ width: 130 }}
+              value={draftConfig[key] ?? config?.[key] ?? ''}
+              onChange={(e) =>
+                setDraftConfig((p) => ({ ...p, [key]: Number(e.target.value) }))
+              }
+              inputProps={{ step: 0.05, min: 0 }}
+            />
+          ))}
+          <Button
+            variant="outlined"
+            disabled={updateConfig.isPending || Object.keys(draftConfig).length === 0}
+            onClick={handleSaveConfig}
+          >
+            Salvar
+          </Button>
+        </Stack>
+      </Paper>
+
+      {isLoading ? (
+        <Box display="flex" justifyContent="center" alignItems="center" py={6}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <Paper>
+          <Stack
+            direction="row"
+            spacing={2}
+            alignItems="center"
+            flexWrap="wrap"
+            useFlexGap
+            sx={{ p: 2, pb: 1 }}
+          >
+            <TextField
+              size="small"
+              label="Buscar jogador"
+              value={search}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setPage(1);
+              }}
+              sx={{ width: 220 }}
+            />
+            <TextField
+              select
+              size="small"
+              label="Disponibilidade"
+              value={availabilityFilter}
+              onChange={(e) => {
+                setAvailabilityFilter(e.target.value as 'ALL' | AvailabilityStatus);
+                setPage(1);
+              }}
+              sx={{ width: 180 }}
+            >
+              <MenuItem value="ALL">Todas</MenuItem>
+              {(Object.keys(STATUS_LABELS) as AvailabilityStatus[]).map((s) => (
+                <MenuItem key={s} value={s}>
+                  {STATUS_LABELS[s]}
+                </MenuItem>
+              ))}
+            </TextField>
+            <TextField
+              select
+              size="small"
+              label="Time"
+              value={teamFilter}
+              onChange={(e) => {
+                setTeamFilter(e.target.value);
+                setPage(1);
+              }}
+              sx={{ width: 180 }}
+            >
+              <MenuItem value="ALL">Todos</MenuItem>
+              {teamOptions.map((t) => (
+                <MenuItem key={t} value={t}>
+                  {t}
+                </MenuItem>
+              ))}
+            </TextField>
+            <TextField
+              select
+              size="small"
+              label="Posição"
+              value={positionFilter}
+              onChange={(e) => {
+                setPositionFilter(e.target.value);
+                setPage(1);
+              }}
+              sx={{ width: 160 }}
+            >
+              <MenuItem value="ALL">Todas</MenuItem>
+              {positionOptions.map((p) => (
+                <MenuItem key={p} value={p}>
+                  {p}
+                </MenuItem>
+              ))}
+            </TextField>
+            <Typography variant="caption" color="text.secondary">
+              {filtered.length} jogadores
+            </Typography>
+          </Stack>
+          <TableContainer sx={{ maxHeight: '65vh' }}>
+            <Table size="small" stickyHeader>
+              <TableHead>
+                <TableRow>
+                  <TableCell>#</TableCell>
+                  <TableCell>Jogador</TableCell>
+                  <TableCell>Time</TableCell>
+                  <TableCell>Pos</TableCell>
+                  <TableCell align="right">Pontuação auto</TableCell>
+                  <TableCell>Disponibilidade</TableCell>
+                  <TableCell align="right">Ajuste manual</TableCell>
+                  <TableCell align="right">Pontuação final</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {pageRows.map((row) => (
+                  <TableRow key={row.playerId} hover>
+                    <TableCell>{row.draftRank}</TableCell>
+                    <TableCell>{row.name}</TableCell>
+                    <TableCell>{row.teamName ?? '—'}</TableCell>
+                    <TableCell>{row.position}</TableCell>
+                    <TableCell align="right">
+                      {Number(row.autoStatScore).toFixed(1)}
+                    </TableCell>
+                    <TableCell>
+                      <Select
+                        size="small"
+                        value={row.availabilityStatus}
+                        disabled={setAvailability.isPending}
+                        onChange={(e) =>
+                          setAvailability.mutate(
+                            {
+                              playerId: row.playerId,
+                              status: e.target.value as AvailabilityStatus,
+                            },
+                            {
+                              onSuccess: () =>
+                                setSnack(`${row.name}: disponibilidade atualizada.`),
+                              onError: (err) =>
+                                setSnack(`Erro: ${(err as Error).message}`),
+                            },
+                          )
+                        }
+                        sx={{ minWidth: 160 }}
+                      >
+                        {(
+                          Object.keys(STATUS_LABELS) as AvailabilityStatus[]
+                        ).map((s) => (
+                          <MenuItem key={s} value={s}>
+                            {STATUS_LABELS[s]}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </TableCell>
+                    <TableCell align="right">
+                      <NudgeField
+                        key={`${row.playerId}-${row.manualNudge}`}
+                        value={Number(row.manualNudge)}
+                        onCommit={(nudge) =>
+                          setNudge.mutate(
+                            { playerId: row.playerId, nudge },
+                            {
+                              onSuccess: () =>
+                                setSnack(`${row.name}: ajuste manual salvo.`),
+                              onError: (err) =>
+                                setSnack(`Erro: ${(err as Error).message}`),
+                            },
+                          )
+                        }
+                      />
+                    </TableCell>
+                    <TableCell align="right">
+                      {Number(row.finalScore).toFixed(1)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+          {totalPages > 1 && (
+            <Box display="flex" justifyContent="center" sx={{ py: 1.5 }}>
+              <Pagination
+                count={totalPages}
+                page={safePage}
+                onChange={(_, p) => setPage(p)}
+                size="small"
+              />
+            </Box>
+          )}
+        </Paper>
+      )}
+
+      <Snackbar
+        open={snack != null}
+        autoHideDuration={4000}
+        onClose={() => setSnack(null)}
+        message={snack}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      />
+    </Box>
+  );
+};
+
+export default PlayerRankingTab;


### PR DESCRIPTION
Add the 'Ranking de Jogadores' admin tab (Recalcular, tunable injury multipliers, paginated/filterable table with per-player availability and manual nudge). Players tab defaults to sortBy=auto: per-league points in-season, global draftRank pre-season; draft search uses draftRank.

Fix /admin infinite-redirect loop and give each admin tab its own URL (/admin/:tab) for deep-linking and refresh-safe navigation.