### PR TITLE
feat(league): cap round count from /current-season budget

### DIFF
--- a/src/api/currentSeasonQueries.ts
+++ b/src/api/currentSeasonQueries.ts
@@ -3,8 +3,13 @@ import axios from 'axios';
 import { apiConfig } from './config';
 import { STALE_TIME } from './queryConfig';
 
-interface CurrentSeason {
+export interface CurrentSeason {
   year: number;
+  realCurrentRound: number | null;
+  maxRealRound: number;
+  minRounds: number; // floor for a fantasy season (12)
+  maxRounds: number; // real rounds left to play (shrinks as the season advances)
+  canCreate: boolean; // false once the real season is past the creation cutoff
 }
 
 export const useCurrentSeason = () => {

--- a/src/components/CreateLeagueModal.tsx
+++ b/src/components/CreateLeagueModal.tsx
@@ -18,6 +18,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { useCreateFantasyLeague } from '../api/fantasyLeagueMutations';
+import { useCurrentSeason } from '../api/currentSeasonQueries';
 import {
   CREATION_CUTOFF_ROUND,
   DEFAULT_ROUNDS,
@@ -47,8 +48,6 @@ const modalStyle = {
 interface CreateLeagueModalProps {
   open: boolean;
   handleClose: () => void;
-  realCurrentRound?: number | null;
-  maxRealRound?: number | null;
 }
 
 const draftTypes = [
@@ -64,7 +63,7 @@ const draftTypes = [
   },
 ];
 
-const CreateLeagueModal: React.FC<CreateLeagueModalProps> = ({ open, handleClose, realCurrentRound, maxRealRound }) => {
+const CreateLeagueModal: React.FC<CreateLeagueModalProps> = ({ open, handleClose }) => {
   const { user } = useAuth();
   const navigate = useNavigate();
   const [leagueName, setLeagueName] = useState('');
@@ -72,30 +71,29 @@ const CreateLeagueModal: React.FC<CreateLeagueModalProps> = ({ open, handleClose
   const [draftType, setDraftType] = useState('snake');
   const { mutate: createFantasyLeague, isPending, isError, error } = useCreateFantasyLeague();
 
-  const maxAllowed = useMemo(() => {
-    if (maxRealRound != null && realCurrentRound != null) {
-      return maxRealRound - realCurrentRound + 1;
-    }
-    return null;
-  }, [maxRealRound, realCurrentRound]);
+  // Round budget comes straight from the backend so it's correct even for a brand
+  // new user with no leagues yet. maxRounds shrinks as the real season advances.
+  const { data: currentSeason } = useCurrentSeason();
+  const minAllowed = currentSeason?.minRounds ?? MIN_ROUNDS;
+  const maxAllowed = currentSeason?.maxRounds ?? null;
 
   const roundOptions = useMemo(() => {
-    const all = Array.from({ length: 20 }, (_, i) => MIN_ROUNDS + i);
+    const all = Array.from({ length: 20 }, (_, i) => minAllowed + i);
     return maxAllowed != null ? all.filter((v) => v <= maxAllowed) : all;
-  }, [maxAllowed]);
+  }, [minAllowed, maxAllowed]);
 
   const [numberOfRounds, setNumberOfRounds] = useState(() =>
     Math.min(DEFAULT_ROUNDS, maxAllowed ?? DEFAULT_ROUNDS),
   );
 
-  // Recalculate default when real round info loads
+  // Recalculate default when the round budget loads
   React.useEffect(() => {
     if (maxAllowed != null) {
       setNumberOfRounds((prev) => Math.min(prev, maxAllowed));
     }
   }, [maxAllowed]);
 
-  const isPastCutoff = realCurrentRound != null && realCurrentRound > CREATION_CUTOFF_ROUND;
+  const isPastCutoff = currentSeason ? !currentSeason.canCreate : false;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/FantasyLeagueSeasonForm.tsx
+++ b/src/components/FantasyLeagueSeasonForm.tsx
@@ -13,6 +13,7 @@ import {
   Typography,
 } from '@mui/material';
 import { useUpdateFantasyLeagueSeason } from '../api/fantasyLeagueSeasonsMutation';
+import { useCurrentSeason } from '../api/currentSeasonQueries';
 
 const SEASON_LOCKED_STATUSES = [
   'DRAFT_SCHEDULED', 'DRAFT_LIVE', 'DRAFT_DONE',
@@ -25,17 +26,20 @@ interface Props {
   id: any;
   refetchFantasyLeagueSeason: () => void;
   seasonStatus?: string;
-  maxRealRound?: number | null;
 }
 
-const FantasyLeagueSeasonForm: React.FC<Props> = ({ values, onChange, id, refetchFantasyLeagueSeason, seasonStatus, maxRealRound }) => {
+const FantasyLeagueSeasonForm: React.FC<Props> = ({ values, onChange, id, refetchFantasyLeagueSeason, seasonStatus }) => {
   const isLocked = !!seasonStatus && SEASON_LOCKED_STATUSES.includes(seasonStatus);
   const [openSnackbar, setOpenSnackbar] = useState(false);
-  // The fantasy season can't need more rounds than the championship has left
+  // The fantasy season can't need more rounds than the championship has LEFT (the
+  // available count, not the absolute last round). Comes from the backend budget.
+  const { data: currentSeason } = useCurrentSeason();
+  const minRounds = currentSeason?.minRounds ?? 12;
+  const maxRounds = currentSeason?.maxRounds ?? null;
   const roundOptions = useMemo(() => {
-    const all = Array.from({ length: 20 }, (_, i) => 12 + i);
-    return maxRealRound ? all.filter((v) => v <= maxRealRound) : all;
-  }, [maxRealRound]);
+    const all = Array.from({ length: 20 }, (_, i) => minRounds + i);
+    return maxRounds != null ? all.filter((v) => v <= maxRounds) : all;
+  }, [minRounds, maxRounds]);
   const tradeDeadlineOptions = useMemo(() => {
     const start = Math.max(1, values.numberOfRounds - 8);
     const end = values.numberOfRounds - 3;
@@ -98,9 +102,9 @@ const FantasyLeagueSeasonForm: React.FC<Props> = ({ values, onChange, id, refetc
       {/* Número de Rodadas */}
       <Box>
         <Typography fontWeight={600}>Número de Rodadas</Typography>
-        {maxRealRound != null && (
+        {maxRounds != null && (
           <Typography variant="body2" color="text.secondary">
-            Máximo permitido pelo calendário do campeonato: {maxRealRound}.
+            Máximo disponível no campeonato: {maxRounds} rodadas.
           </Typography>
         )}
         <FormControl fullWidth>

--- a/src/components/FantasyLeagueSettingsModal.tsx
+++ b/src/components/FantasyLeagueSettingsModal.tsx
@@ -114,7 +114,6 @@ const FantasyLeagueSettingsModal: React.FC<Props> = ({ open, onClose, fantasyLea
             id={fantasyLeagueSeason?.id!}
             refetchFantasyLeagueSeason={refetchFantasyLeagueSeason}
             seasonStatus={fantasyLeagueSeason?.status}
-            maxRealRound={fantasyLeagueSeason?.maxRealRound}
           />
         );
       case 'roster':

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -7,7 +7,6 @@ import CreateLeagueModal from '../components/CreateLeagueModal';
 import JoinLeagueModal from '../components/JoinLeagueModal';
 import { UserFantasyLeaguesList } from '../components/UserFantasyLeaguesList';
 import { useGetMyLeagues } from '../api/fantasyLeagueQueries';
-import { useFantasyLeagueSeasons } from '../api/useFantasyLeagueSeasons';
 import { apiConfig } from '../api/config';
 import { useMutation } from '@tanstack/react-query';
 import Loading from '../components/Loading';
@@ -28,10 +27,6 @@ const Welcome = () => {
   
   // Use the React Query hook
   const { data: fantasyLeagues, isLoading, isError, error } = useGetMyLeagues();
-
-  // Use first available league's season to get real-round budget info for CreateLeagueModal
-  const firstLeagueId = fantasyLeagues?.[0]?.id ?? 0; // 0 disables the query (enabled: !!leagueId)
-  const { data: firstLeagueSeason } = useFantasyLeagueSeasons(firstLeagueId);
 
 const acceptInviteMutation = useMutation({
   mutationFn: async (token: string) => {
@@ -180,8 +175,6 @@ const acceptInviteMutation = useMutation({
       <CreateLeagueModal
         open={isModalOpen}
         handleClose={() => setIsModalOpen(false)}
-        realCurrentRound={firstLeagueSeason?.realCurrentRound ?? null}
-        maxRealRound={firstLeagueSeason?.maxRealRound ?? null}
       />
 
       <JoinLeagueModal


### PR DESCRIPTION
Both the create and settings round dropdowns now read the rounds-left budget from useCurrentSeason instead of piggybacking on an existing league season. Fixes the missing cap for new users with no leagues, and the settings modal capping at the absolute last round instead of rounds remaining.