### PR TITLE
feat(ux): signin polish, draft scheduling + disclaimer, tab persistence

### DIFF
--- a/src/api/fantasyLeagueMutations.ts
+++ b/src/api/fantasyLeagueMutations.ts
@@ -65,7 +65,9 @@ export const inviteUserToFantasyLeague = async ({
       'Content-Type': 'application/json',
       Authorization: `Bearer ${getToken()}`,
     },
-    body: JSON.stringify({ email, id }),
+    // BE DTO expects { email, fantasyLeagueId: int } — send the right field name,
+    // coerced to a number (route params arrive as strings).
+    body: JSON.stringify({ email, fantasyLeagueId: Number(id) }),
   });
 
   if (!res.ok) {

--- a/src/api/useDraftSettingsMutations.ts
+++ b/src/api/useDraftSettingsMutations.ts
@@ -11,7 +11,9 @@ export interface DraftSettings {
     season: number;
   };
 
-export const useUpdateDraftSettings = ({ onSuccess }: { onSuccess: () => void }) => {
+export const useUpdateDraftSettings = (
+  { onSuccess }: { onSuccess?: () => void } = {},
+) => {
   return useMutation({
     mutationFn: ({ id, updates }: { id: number; updates: DraftSettings }) =>
       axios.patch(`${apiConfig.endpoints.draftSettings.update(id)}`, updates, {
@@ -20,6 +22,6 @@ export const useUpdateDraftSettings = ({ onSuccess }: { onSuccess: () => void })
           Authorization: `Bearer ${getToken()}`,
         },
       }),
-    onSuccess: onSuccess,
+    onSuccess,
   });
 };

--- a/src/api/useFantasyLeagueSeasons.ts
+++ b/src/api/useFantasyLeagueSeasons.ts
@@ -8,7 +8,6 @@ export interface FantasyLeagueSeason {
   numberOfTeams: number;
   playoffTeams: number;
   tradeDeadlineRound: number;
-  irSlots: number;
   playoffStartRound: number;
   numberOfRounds: number;
   // Originally-requested round count if the season was shortened at schedule

--- a/src/api/useRosterSettings.ts
+++ b/src/api/useRosterSettings.ts
@@ -8,7 +8,6 @@ export interface RosterSettingsResponse {
   numberOfTeams: number;
   playoffTeams: number;
   tradeDeadlineRound: number;
-  irSlots: number;
   playoffStartRound: number;
   defenseType?: 'OPEN' | 'CLOSED';
 }

--- a/src/components/DraftSchedulePanel.tsx
+++ b/src/components/DraftSchedulePanel.tsx
@@ -53,47 +53,51 @@ export default function DraftSchedulePanel({
   isOwner,
   refetchDraftSettings,
 }: Props) {
-  const hasDate = !!draftSettings.draftDate;
   const { data: draftOrder } = useDraftOrder(leagueId, draftSettings.season);
   const hasDraftOrder = !!draftOrder && draftOrder.length > 0;
 
   const [newDate, setNewDate] = useState(
     draftSettings.draftDate ? toLocalDatetimeValue(draftSettings.draftDate) : '',
   );
-  const [changeDateOpen, setChangeDateOpen] = useState(false);
   const [scheduleConfirmOpen, setScheduleConfirmOpen] = useState(false);
   const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({
     open: false, message: '', severity: 'success',
   });
 
-  const { mutate: updateSettings, isPending: isSavingDate } = useUpdateDraftSettings({
-    onSuccess: () => {
-      refetchDraftSettings();
-      setChangeDateOpen(false);
-      setSnackbar({ open: true, message: 'Data do draft salva!', severity: 'success' });
-    },
-  });
-
+  const { mutate: updateSettings } = useUpdateDraftSettings();
   const { mutate: scheduleDraft, isPending: isScheduling } = useScheduleDraft(leagueId);
 
-  const handleSaveDate = () => {
-    updateSettings({ id: draftSettings.id, updates: { ...draftSettings, draftDate: new Date(newDate).toISOString() } });
-  };
-
-  const handleSchedule = () => {
+  // Single irreversible action: persist the chosen date, then schedule the draft.
+  // (Scheduling reads draftDate from the DB, so the save must land first.) This
+  // replaces the old two-step "Salvar Data" → "Agendar Draft" flow, where users
+  // could save the date and wrongly assume the draft was already scheduled.
+  const handleConfirmSchedule = () => {
     setScheduleConfirmOpen(false);
-    scheduleDraft(seasonId, {
-      onSuccess: () =>
-        setSnackbar({ open: true, message: 'Draft agendado com sucesso!', severity: 'success' }),
-      onError: (err) =>
-        setSnackbar({ open: true, message: getErrorMessage(err), severity: 'error' }),
-    });
+    updateSettings(
+      {
+        id: draftSettings.id,
+        updates: { ...draftSettings, draftDate: new Date(newDate).toISOString() },
+      },
+      {
+        onSuccess: () => {
+          refetchDraftSettings();
+          scheduleDraft(seasonId, {
+            onSuccess: () =>
+              setSnackbar({ open: true, message: 'Draft agendado com sucesso!', severity: 'success' }),
+            onError: (err) =>
+              setSnackbar({ open: true, message: getErrorMessage(err), severity: 'error' }),
+          });
+        },
+        onError: (err) =>
+          setSnackbar({ open: true, message: getErrorMessage(err), severity: 'error' }),
+      },
+    );
   };
 
   const minDateTime = toLocalDatetimeValue(new Date(Date.now() + 60000).toISOString());
 
-  const formattedDate = hasDate
-    ? new Date(draftSettings.draftDate).toLocaleString('pt-BR', {
+  const formattedNewDate = newDate
+    ? new Date(newDate).toLocaleString('pt-BR', {
         day: '2-digit', month: 'long', year: 'numeric', hour: '2-digit', minute: '2-digit',
       })
     : null;
@@ -104,13 +108,10 @@ export default function DraftSchedulePanel({
         Data do Draft
       </Typography>
 
-      {/* No date yet */}
-      {!hasDate && isOwner && (
+      {isOwner && (
         <>
-          <Alert severity="warning" sx={{ mb: 2 }}>
-            Nenhuma data definida. Defina uma data para poder agendar o draft.
-          </Alert>
           <Box display="flex" gap={1} alignItems="center" mb={2}>
+            <CalendarMonthIcon color="primary" />
             <TextField
               type="datetime-local"
               size="small"
@@ -119,99 +120,23 @@ export default function DraftSchedulePanel({
               slotProps={{ htmlInput: { min: minDateTime } }}
               sx={{ flex: 1 }}
             />
-            <Button
-              variant="contained"
-              onClick={handleSaveDate}
-              disabled={isSavingDate || !newDate}
-              sx={{ borderRadius: 50, textTransform: 'none', fontWeight: 600, whiteSpace: 'nowrap' }}
-            >
-              {isSavingDate ? 'Salvando…' : 'Salvar Data'}
-            </Button>
-          </Box>
-        </>
-      )}
-
-      {/* Date is set */}
-      {hasDate && (
-        <>
-          <Box
-            display="flex"
-            alignItems="center"
-            gap={1.5}
-            sx={{
-              p: 2,
-              borderRadius: 1,
-              border: '1px solid',
-              borderColor: 'divider',
-              mb: 1.5,
-            }}
-          >
-            <CalendarMonthIcon color="primary" />
-            <Typography fontWeight={600}>{formattedDate}</Typography>
-            {isOwner && (
-              <Button
-                size="small"
-                sx={{ ml: 'auto', textTransform: 'none' }}
-                onClick={() => {
-                  setNewDate(toLocalDatetimeValue(draftSettings.draftDate!));
-                  setChangeDateOpen(true);
-                }}
-              >
-                Alterar
-              </Button>
-            )}
           </Box>
 
-          {isOwner && (
-            <Alert severity="info" sx={{ mb: 2 }}>
-              O dia e hora do draft ainda precisa ser confirmado. Clique em "Agendar Draft" para finalizar.
-            </Alert>
-          )}
-
-          {isOwner && (
-            <Button
-              variant="contained"
-              onClick={() => setScheduleConfirmOpen(true)}
-              disabled={isScheduling}
-              sx={{ borderRadius: 50, textTransform: 'none', fontWeight: 700 }}
-            >
-              {isScheduling ? 'Agendando…' : 'Agendar Draft'}
-            </Button>
-          )}
-        </>
-      )}
-
-      {/* Change date dialog */}
-      <Dialog open={changeDateOpen} onClose={() => setChangeDateOpen(false)}>
-        <DialogTitle>Alterar Data do Draft</DialogTitle>
-        <DialogContent>
-          <TextField
-            type="datetime-local"
-            size="small"
-            fullWidth
-            value={newDate}
-            onChange={(e) => setNewDate(e.target.value)}
-            slotProps={{ htmlInput: { min: minDateTime } }}
-            sx={{ mt: 1, mb: 2 }}
-          />
-          <Alert severity="info" sx={{ fontSize: '0.8rem' }}>
-            Salvar a data não agenda o draft. Você ainda precisará clicar em "Agendar Draft" para confirmar.
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            Escolha a data e clique em <strong>Agendar Draft</strong>. Esta ação é
+            irreversível: depois de agendado, o draft não pode ser desfeito.
           </Alert>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setChangeDateOpen(false)} sx={{ textTransform: 'none' }}>
-            Cancelar
-          </Button>
+
           <Button
             variant="contained"
-            disabled={isSavingDate || !newDate}
-            onClick={handleSaveDate}
-            sx={{ textTransform: 'none' }}
+            onClick={() => setScheduleConfirmOpen(true)}
+            disabled={isScheduling || !newDate}
+            sx={{ borderRadius: 50, textTransform: 'none', fontWeight: 700 }}
           >
-            {isSavingDate ? 'Salvando…' : 'Salvar Data'}
+            {isScheduling ? 'Agendando…' : 'Agendar Draft'}
           </Button>
-        </DialogActions>
-      </Dialog>
+        </>
+      )}
 
       {/* Schedule confirmation dialog */}
       <Dialog open={scheduleConfirmOpen} onClose={() => setScheduleConfirmOpen(false)}>
@@ -221,7 +146,7 @@ export default function DraftSchedulePanel({
             O draft será agendado para:
           </Typography>
           <Typography fontWeight={700} mb={2}>
-            {formattedDate}
+            {formattedNewDate}
           </Typography>
           {!hasDraftOrder && (
             <Alert severity="warning" sx={{ mb: 1.5 }}>
@@ -229,7 +154,8 @@ export default function DraftSchedulePanel({
             </Alert>
           )}
           <Alert severity="warning">
-            Esta ação não pode ser desfeita. Após confirmar, o agendamento estará bloqueado.
+            Esta ação não pode ser desfeita. Após confirmar, a data fica salva e o
+            draft é agendado.
           </Alert>
         </DialogContent>
         <DialogActions>
@@ -238,7 +164,7 @@ export default function DraftSchedulePanel({
           </Button>
           <Button
             variant="contained"
-            onClick={handleSchedule}
+            onClick={handleConfirmSchedule}
             disabled={isScheduling}
             sx={{ textTransform: 'none' }}
           >

--- a/src/components/DraftSettingsForm.tsx
+++ b/src/components/DraftSettingsForm.tsx
@@ -57,7 +57,7 @@ const DraftSettingsForm: React.FC<Props> = ({
             onChange={(e) => onChange('draftType', e.target.value)}
             disabled={isLocked}
           >
-            <MenuItem value="snake">Snake</MenuItem>
+            <MenuItem value="snake">Vai e Vem</MenuItem>
             <MenuItem value="linear">Linear</MenuItem>
           </Select>
         </FormControl>

--- a/src/components/DraftTab.tsx
+++ b/src/components/DraftTab.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, Button, CircularProgress, Divider, Stack, Typography } from '@mui/material';
+import { Alert, AlertTitle, Box, Button, CircularProgress, Divider, Stack, Typography } from '@mui/material';
 import { FantasyLeague, useFantasyLeagueTeams } from '../api/fantasyLeagueQueries';
 import { useFantasyLeagueSeasons } from '../api/useFantasyLeagueSeasons';
 import { useDraftSettings } from '../api/useDraftSettings';
@@ -50,6 +50,17 @@ export default function DraftTab({ fantasyLeague, currentUserId }: Props) {
   if (status === LeagueStatus.ACTIVATED_PRESEASON) {
     return (
       <Box>
+        {isOwner && (
+          <Alert severity="warning" sx={{ mb: 1 }}>
+            <AlertTitle sx={{ fontWeight: 700 }}>
+              Antes de agendar o draft, revise as configurações
+            </AlertTitle>
+            Após o draft ser realizado, várias configurações da liga não poderão
+            mais ser alteradas. Recomendamos conferir as configurações desta liga
+            (aba <strong>Liga</strong>) e do draft abaixo antes de agendar.
+          </Alert>
+        )}
+
         {isOwner && draftSettings && (
           <>
             <Divider sx={{ my: 3 }} />

--- a/src/components/FantasyLeagueSeasonForm.tsx
+++ b/src/components/FantasyLeagueSeasonForm.tsx
@@ -162,24 +162,6 @@ const FantasyLeagueSeasonForm: React.FC<Props> = ({ values, onChange, id, refetc
         </FormControl>
       </Box>
 
-      {/* Reservas por Lesão */}
-      <Box>
-        <Typography fontWeight={600}>Reservas por Lesão</Typography>
-        <FormControl fullWidth>
-          <Select
-            value={values.irSlots ?? ''}
-            onChange={(e) => onChange('irSlots', e.target.value)}
-            disabled={isLocked}
-          >
-            {Array.from({ length: 9 }, (_, i) => (
-              <MenuItem key={i} value={i}>
-                {i}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-      </Box>
-
       {/* Formato dos Playoffs */}
       <Box>
         <Typography fontWeight={600}>Formato dos Playoffs</Typography>

--- a/src/components/FantasyLeagueSettings.tsx
+++ b/src/components/FantasyLeagueSettings.tsx
@@ -27,7 +27,6 @@ const FantasyLeagueSettings: React.FC<Props> = ({ isOwner = false, fantasyLeague
     numberOfTeams: fantasyLeagueSeason?.numberOfTeams,
     playoffs: fantasyLeagueSeason?.playoffTeams,
     tradeDeadline: fantasyLeagueSeason?.tradeDeadlineRound,
-    irSlots: fantasyLeagueSeason?.irSlots,
     playoffStartRound: fantasyLeagueSeason?.playoffStartRound,
   };
 
@@ -69,10 +68,6 @@ const FantasyLeagueSettings: React.FC<Props> = ({ isOwner = false, fantasyLeague
           <TableRow>
             <TableCell sx={{ color: 'text.secondary' }}>Rodada Limite para Trocas</TableCell>
             <TableCell>{settings.tradeDeadline}a</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell sx={{ color: 'text.secondary' }}>Vagas para Lesionados</TableCell>
-            <TableCell>{settings.irSlots}</TableCell>
           </TableRow>
         </TableBody>
       </Table>

--- a/src/ds/RadioGroup/RadioGroup.stories.tsx
+++ b/src/ds/RadioGroup/RadioGroup.stories.tsx
@@ -27,7 +27,7 @@ type S = StoryObj<typeof RadioGroup>
 
 const DRAFT_OPTIONS = (
   <>
-    <Radio value="snake" label="Snake" />
+    <Radio value="snake" label="Vai e Vem" />
     <Radio value="linear" label="Linear" />
     <Radio value="auction" label="Auction" />
   </>
@@ -100,7 +100,7 @@ export const WithDisabledOption: S = {
         value={value}
         onChange={setValue}
       >
-        <Radio value="snake" label="Snake" />
+        <Radio value="snake" label="Vai e Vem" />
         <Radio value="linear" label="Linear" />
         <Radio value="auction" label="Auction (em breve)" disabled />
       </RadioGroup>

--- a/src/pages/FantasyLeague.tsx
+++ b/src/pages/FantasyLeague.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import { useGetFantasyLeague } from '../api/fantasyLeagueQueries';
 import LeagueSidebar from '../components/FantasyLeaguesSidebar';
 import InviteToLeagueModal from '../components/InviteToFantasyLeagueModal';
@@ -24,6 +24,19 @@ import { useTrades } from '../api/tradeQueries';
 import ScoringConfigForm from '../components/ScoringConfigForm';
 import RodadaTab from '../components/RodadaTab';
 
+// Tab keys mirror FantasyLeagueTabs.tsx — kept in sync so an unknown ?tab= value
+// falls back to the default instead of rendering a blank panel.
+const VALID_TAB_KEYS = [
+  'draft',
+  'team',
+  'schedule',
+  'rodada',
+  'league',
+  'players',
+  'trades',
+  'scores',
+];
+
 const FantasyLeaguePage = ({ currentUserId }: { currentUserId: number }) => {
   const { fantasyLeagueId } = useParams<{ fantasyLeagueId: string }>();
   const { data: fantasyLeague, isLoading, isError, error } = useGetFantasyLeague(Number(fantasyLeagueId));
@@ -33,8 +46,27 @@ const FantasyLeaguePage = ({ currentUserId }: { currentUserId: number }) => {
     message: '',
     severity: 'success' as 'success' | 'error',
   });
-  const [selectedTab, setSelectedTab] = useState('draft');
-  const [defaultTabSet, setDefaultTabSet] = useState(false);
+  // Persist the active tab in the URL (?tab=) so a refresh / shared link keeps
+  // the user where they were instead of snapping back to the default.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const urlTab = searchParams.get('tab');
+  const initialTab = urlTab && VALID_TAB_KEYS.includes(urlTab) ? urlTab : 'draft';
+  const [selectedTab, setSelectedTab] = useState(initialTab);
+  // If the URL already pins a valid tab, the smart-default effect must not override it.
+  const [defaultTabSet, setDefaultTabSet] = useState(
+    !!urlTab && VALID_TAB_KEYS.includes(urlTab),
+  );
+
+  const handleTabChange = (key: string) => {
+    setSelectedTab(key);
+    setSearchParams(
+      (prev) => {
+        prev.set('tab', key);
+        return prev;
+      },
+      { replace: true },
+    );
+  };
   const [viewInvitesModalOpen, setViewInvitesModalOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
   const theme = useTheme();
@@ -47,8 +79,9 @@ const FantasyLeaguePage = ({ currentUserId }: { currentUserId: number }) => {
   const POST_DRAFT_STATUSES = ['DRAFT_DONE', 'SCHEDULED', 'ACTIVE', 'SEASON_ENDED', 'ARCHIVED'];
   useEffect(() => {
     if (!defaultTabSet && fantasyLeagueSeason?.status) {
+      // Only applies when the URL didn't already pin a tab (defaultTabSet guards that).
       if (POST_DRAFT_STATUSES.includes(fantasyLeagueSeason.status)) {
-        setSelectedTab('rodada');
+        handleTabChange('rodada');
       }
       setDefaultTabSet(true);
     }
@@ -132,7 +165,7 @@ const FantasyLeaguePage = ({ currentUserId }: { currentUserId: number }) => {
         px={isMobile ? 2 : 4}
         py={isMobile ? 2 : 4}
       >
-        <LeagueTabs selected={selectedTab} onChange={setSelectedTab} pendingTradesCount={pendingTradesCount} />
+        <LeagueTabs selected={selectedTab} onChange={handleTabChange} pendingTradesCount={pendingTradesCount} />
 
         <Box mt={4}>
           {selectedTab === 'draft' && <DraftTab fantasyLeague={fantasyLeague} currentUserId={currentUserId} />}

--- a/src/pages/SignIn.test.tsx
+++ b/src/pages/SignIn.test.tsx
@@ -43,17 +43,19 @@ describe('SignIn', () => {
     expect(screen.getByText(/monte o time/i)).toBeInTheDocument()
   })
 
-  it('keeps the richer affordances (remember-me, forgot-password, OU, social)', () => {
+  it('keeps the richer affordances (forgot-password, OU, social)', () => {
     renderSignIn()
     expect(
-      screen.getByRole('checkbox', { name: /manter conectado/i }),
-    ).toBeInTheDocument()
+      screen.queryByRole('checkbox', { name: /manter conectado/i }),
+    ).not.toBeInTheDocument()
     expect(
       screen.getByRole('link', { name: /esqueci a senha/i }),
     ).toBeInTheDocument()
     expect(screen.getByText(/^ou$/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /^google$/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /^apple$/i })).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /^apple$/i }),
+    ).not.toBeInTheDocument()
     expect(screen.getByRole('link', { name: /cadastre-se/i })).toBeInTheDocument()
   })
 

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -13,7 +13,6 @@ import {
   ArchShape,
   Azulejo,
   Btn,
-  Checkbox,
   FieldGroup,
   Help,
   Icon,
@@ -70,6 +69,37 @@ function displayStyle(
   }
 }
 
+/** The official multicolor Google "G" brand mark (inline so it keeps its colors
+ * on the neutral outline button — the monochrome DS Icon set can't carry it). */
+function GoogleLogo() {
+  return (
+    <svg
+      width={18}
+      height={18}
+      viewBox="0 0 18 18"
+      aria-hidden="true"
+      className="shrink-0"
+    >
+      <path
+        fill="#4285F4"
+        d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.71-1.57 2.68-3.88 2.68-6.62Z"
+      />
+      <path
+        fill="#34A853"
+        d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.8.54-1.84.86-3.04.86-2.34 0-4.32-1.58-5.02-3.7H.96v2.34A9 9 0 0 0 9 18Z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M3.98 10.72A5.4 5.4 0 0 1 3.7 9c0-.6.1-1.18.28-1.72V4.94H.96A9 9 0 0 0 0 9c0 1.45.35 2.82.96 4.06l3.02-2.34Z"
+      />
+      <path
+        fill="#EA4335"
+        d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58C13.46.89 11.43 0 9 0A9 9 0 0 0 .96 4.94L3.98 7.28C4.68 5.16 6.66 3.58 9 3.58Z"
+      />
+    </svg>
+  )
+}
+
 interface PasswordFieldProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> {
   invalid?: boolean
@@ -94,7 +124,7 @@ function PasswordField({ invalid, ...inputProps }: PasswordFieldProps) {
         {...inputProps}
         type={visible ? 'text' : 'password'}
         invalid={invalid}
-        className="pr-[78px]"
+        className="!pr-11"
       />
       <button
         type="button"
@@ -102,10 +132,9 @@ function PasswordField({ invalid, ...inputProps }: PasswordFieldProps) {
         aria-label={label}
         title={label}
         onClick={() => setVisible((v) => !v)}
-        className="absolute right-2 top-1/2 inline-flex -translate-y-1/2 items-center gap-1 rounded-pill font-sans text-[11px] font-bold uppercase tracking-[1px] text-ink-muted transition-colors duration-150 hover:text-ink"
+        className="absolute right-3 top-1/2 inline-flex -translate-y-1/2 items-center justify-center rounded-pill p-1 text-ink-muted transition-colors duration-150 hover:text-ink"
       >
-        <Icon name={visible ? 'eye-off' : 'eye'} size={16} aria-hidden="true" />
-        {label}
+        <Icon name={visible ? 'eye-off' : 'eye'} size={20} aria-hidden="true" />
       </button>
     </div>
   )
@@ -291,8 +320,7 @@ function SignInView() {
               />
             </FieldGroup>
 
-            <div className="mb-7 flex items-center justify-between">
-              <Checkbox name="remember" label="Manter conectado" />
+            <div className="mb-7 flex items-center justify-end">
               <RouterLink
                 to="/forgot-password"
                 className="font-sans text-[12px] font-semibold text-signature underline underline-offset-[3px]"
@@ -301,22 +329,26 @@ function SignInView() {
               </RouterLink>
             </div>
 
-            <Btn
+            <button
               type="submit"
-              variant="primary"
-              size="lg"
-              loading={isPending}
-              className="w-full !justify-between"
+              disabled={isPending}
+              className="flex w-full items-center justify-between rounded-btn-lg px-[30px] font-sans text-[15px] font-bold tracking-[0.3px] transition-transform duration-150 hover:-translate-y-px active:translate-y-px disabled:opacity-60"
+              style={{
+                height: '56px',
+                backgroundColor: '#14402C', // green (signature)
+                color: '#F2F1E8', // cream (on-green)
+                border: '2px solid #C79A2B', // gold border
+              }}
             >
-              <span>Entrar</span>
+              <span>{isPending ? 'Entrando…' : 'Entrar'}</span>
               <span
                 aria-hidden="true"
                 className="font-display text-[22px] tracking-[-1px]"
-                style={{ color: 'var(--gold-light)' }}
+                style={{ color: '#E1C36B' }}
               >
                 →
               </span>
-            </Btn>
+            </button>
           </form>
 
           <div className="my-6 flex items-center gap-3">
@@ -333,22 +365,18 @@ function SignInView() {
             />
           </div>
 
-          <div className="flex gap-2">
-            <Btn
-              type="button"
-              variant="secondary"
-              size="md"
-              className="flex-1"
-              onClick={() => {
-                window.location.href = apiConfig.endpoints.auth.googleAuth
-              }}
-            >
-              Google
-            </Btn>
-            <Btn type="button" variant="secondary" size="md" className="flex-1">
-              Apple
-            </Btn>
-          </div>
+          <Btn
+            type="button"
+            variant="secondary"
+            size="md"
+            className="w-full"
+            onClick={() => {
+              window.location.href = apiConfig.endpoints.auth.googleAuth
+            }}
+          >
+            <GoogleLogo />
+            Google
+          </Btn>
 
           <p className="mt-8 text-center font-sans text-[13px] text-ink-muted">
             Não tem uma conta?{' '}


### PR DESCRIPTION
- SignIn: inline Google logo, remove Apple, icon-only password reveal, drop dead 'Manter conectado', fix Entrar border (inline style)
- Remove unused 'Reservas por Lesão' (irSlots) from settings UI
- Persist active league tab in the URL (?tab=) so refresh keeps it
- Draft: owner-only pre-schedule disclaimer; single confirmed 'Agendar Draft' that saves the date then schedules
- Fix invite-by-email 400 (send fantasyLeagueId, not id)
- PT-BR: 'Snake' -> 'Vai e Vem'